### PR TITLE
Remove two close button

### DIFF
--- a/src/FreeScribe.client/UI/MarkdownWindow.py
+++ b/src/FreeScribe.client/UI/MarkdownWindow.py
@@ -52,10 +52,10 @@ class MarkdownWindow:
             # Add a close button at the bottom center
             close_button = tk.Button(self.window, text="Close", command=lambda: self._on_close(var, callback))
             close_button.pack(side=tk.BOTTOM)  # Extra padding for separation from the checkbox
-
-        # Add a close button at the bottom center
-        close_button = tk.Button(self.window, text="Close", command= self.window.destroy)
-        close_button.pack(side=tk.BOTTOM , pady=5)  # Extra padding for separation from the checkbox
+        else:
+          # Add a close button at the bottom center
+          close_button = tk.Button(self.window, text="Close", command= self.window.destroy)
+          close_button.pack(side=tk.BOTTOM , pady=5)  # Extra padding for separation from the checkbox
 
         self.window.geometry("900x900")
         self.window.lift()

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -412,8 +412,9 @@ class SettingsWindowUI:
         This method creates and places buttons for saving settings, resetting to default,
         and closing the settings window.
         """
-        tk.Button(self.main_frame, text="Save", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
+        tk.Button(self.main_frame, text="Save", command=lambda: self.save_settings(False), width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Default", width=10, command=self.reset_to_default).pack(side="right", padx=2, pady=5)
+        tk.Button(self.main_frame, text="Apply", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Close", width=10, command=self.settings_window.destroy).pack(side="right", padx=2, pady=5)
 
     def save_settings(self, close_window=True):

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -412,7 +412,6 @@ class SettingsWindowUI:
         This method creates and places buttons for saving settings, resetting to default,
         and closing the settings window.
         """
-        tk.Button(self.main_frame, text="Apply", command=lambda: self.save_settings(False), width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Save", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Default", width=10, command=self.reset_to_default).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Close", width=10, command=self.settings_window.destroy).pack(side="right", padx=2, pady=5)

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -412,9 +412,9 @@ class SettingsWindowUI:
         This method creates and places buttons for saving settings, resetting to default,
         and closing the settings window.
         """
+        tk.Button(self.main_frame, text="Apply", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Save", command=lambda: self.save_settings(False), width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Default", width=10, command=self.reset_to_default).pack(side="right", padx=2, pady=5)
-        tk.Button(self.main_frame, text="Apply", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Close", width=10, command=self.settings_window.destroy).pack(side="right", padx=2, pady=5)
 
     def save_settings(self, close_window=True):

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -412,8 +412,8 @@ class SettingsWindowUI:
         This method creates and places buttons for saving settings, resetting to default,
         and closing the settings window.
         """
-        tk.Button(self.main_frame, text="Apply", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
-        tk.Button(self.main_frame, text="Save", command=lambda: self.save_settings(False), width=10).pack(side="right", padx=2, pady=5)
+        tk.Button(self.main_frame, text="Apply", command=lambda: self.save_settings(False), width=10).pack(side="right", padx=2, pady=5)
+        tk.Button(self.main_frame, text="Save", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Default", width=10, command=self.reset_to_default).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Close", width=10, command=self.settings_window.destroy).pack(side="right", padx=2, pady=5)
 


### PR DESCRIPTION
**Issue**: #52 
### Screenshot
![image](https://github.com/user-attachments/assets/67690e53-8e5d-4cb3-a011-24f5f6643d28)

## Summary by Sourcery

Enhance the UI by removing a duplicate close button in the MarkdownWindow 

Enhancements:
- Remove duplicate close button in MarkdownWindow to streamline the UI.