### PR TITLE
[Hot Fix] Residual import causing crash

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -41,7 +41,6 @@ from UI.SettingsWindowUI import SettingsWindowUI
 from UI.SettingsWindow import SettingsWindow
 from UI.Widgets.CustomTextBox import CustomTextBox
 from UI.LoadingWindow import LoadingWindow
-from Model import Model
 
 # GUI Setup
 root = tk.Tk()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove residual import from Model module to prevent application crash.