### PR TITLE
Add close_window method to handle settings window cleanup

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -117,33 +117,33 @@ class SettingsWindowUI:
 
 
     def add_scrollbar_to_frame(self, frame):
-            """
-            Adds a scrollbar to a given frame.
+        """
+        Adds a scrollbar to a given frame.
 
-            Args:
-                frame (tk.Frame): The frame to which the scrollbar will be added.
+        Args:
+            frame (tk.Frame): The frame to which the scrollbar will be added.
 
-            Returns:
-                tk.Frame: The scrollable frame.
-            """
-            canvas = tk.Canvas(frame)
-            scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
-            scrollable_frame = ttk.Frame(canvas)
+        Returns:
+            tk.Frame: The scrollable frame.
+        """
+        canvas = tk.Canvas(frame)
+        scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
+        scrollable_frame = ttk.Frame(canvas)
 
-            scrollable_frame.bind(
-                "<Configure>",
-                lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
-            )
+        scrollable_frame.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
 
-            canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
-            canvas.configure(yscrollcommand=scrollbar.set)
+        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
 
-            canvas.pack(side="left", fill="both", expand=True)
-            scrollbar.pack(side="right", fill="y")
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
 
-            self.settings_window.bind_all("<MouseWheel>", lambda e: canvas.yview_scroll(int(-1*(e.delta/120)), "units"))
+        self.settings_window.bind_all("<MouseWheel>", lambda e: canvas.yview_scroll(int(-1*(e.delta/120)), "units"))
 
-            return scrollable_frame
+        return scrollable_frame
 
     def create_whisper_settings(self):
         """

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -100,6 +100,9 @@ class SettingsWindowUI:
         self.notebook.add(self.advanced_frame, text="Advanced Settings")
         self.notebook.add(self.docker_settings_frame, text="Docker Settings")
 
+        self.settings_window.protocol("WM_DELETE_WINDOW", self.close_window)
+
+
         self.llm_settings_frame = self.add_scrollbar_to_frame(self.llm_settings_frame)
         self.whisper_settings_frame = self.add_scrollbar_to_frame(self.whisper_settings_frame)
         self.advanced_settings_frame = self.add_scrollbar_to_frame(self.advanced_frame)
@@ -112,34 +115,35 @@ class SettingsWindowUI:
         self.create_docker_settings()
         self.create_buttons()
 
+
     def add_scrollbar_to_frame(self, frame):
-        """
-        Adds a scrollbar to a given frame.
+            """
+            Adds a scrollbar to a given frame.
 
-        Args:
-            frame (tk.Frame): The frame to which the scrollbar will be added.
+            Args:
+                frame (tk.Frame): The frame to which the scrollbar will be added.
 
-        Returns:
-            tk.Frame: The scrollable frame.
-        """
-        canvas = tk.Canvas(frame)
-        scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
-        scrollable_frame = ttk.Frame(canvas)
+            Returns:
+                tk.Frame: The scrollable frame.
+            """
+            canvas = tk.Canvas(frame)
+            scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
+            scrollable_frame = ttk.Frame(canvas)
 
-        scrollable_frame.bind(
-            "<Configure>",
-            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
-        )
+            scrollable_frame.bind(
+                "<Configure>",
+                lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+            )
 
-        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
-        canvas.configure(yscrollcommand=scrollbar.set)
+            canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+            canvas.configure(yscrollcommand=scrollbar.set)
 
-        canvas.pack(side="left", fill="both", expand=True)
-        scrollbar.pack(side="right", fill="y")
+            canvas.pack(side="left", fill="both", expand=True)
+            scrollbar.pack(side="right", fill="y")
 
-        self.settings_window.bind_all("<MouseWheel>", lambda e: canvas.yview_scroll(int(-1*(e.delta/120)), "units"))
+            self.settings_window.bind_all("<MouseWheel>", lambda e: canvas.yview_scroll(int(-1*(e.delta/120)), "units"))
 
-        return scrollable_frame
+            return scrollable_frame
 
     def create_whisper_settings(self):
         """
@@ -417,7 +421,7 @@ class SettingsWindowUI:
         """
         tk.Button(self.main_frame, text="Save", command=self.save_settings, width=10).pack(side="right", padx=2, pady=5)
         tk.Button(self.main_frame, text="Default", width=10, command=self.reset_to_default).pack(side="right", padx=2, pady=5)
-        tk.Button(self.main_frame, text="Close", width=10, command=self.settings_window.destroy).pack(side="right", padx=2, pady=5)
+        tk.Button(self.main_frame, text="Close", width=10, command=self.close_window).pack(side="right", padx=2, pady=5)
 
     def save_settings(self, close_window=True):
         """
@@ -455,7 +459,7 @@ class SettingsWindowUI:
             self.main_window.destroy_scribe_template()
 
         if close_window:
-            self.settings_window.destroy()
+            self.close_window()
 
     def reset_to_default(self):
         """
@@ -511,3 +515,14 @@ class SettingsWindowUI:
         entry.insert(0, str(value))
         entry.grid(row=row_idx, column=1, padx=0, pady=5, sticky="w")
         self.settings.editable_settings_entries[setting_name] = entry
+
+    def close_window(self):
+        """
+        Cleans up the settings window.
+
+        This method destroys the settings window and clears the settings entries.
+        """
+        self.settings_window.unbind_all("<MouseWheel>") # Unbind mouse wheel event causing errors
+        self.settings_window.unbind_all("<Configure>") # Unbind the configure event causing errors
+
+        self.settings_window.destroy()


### PR DESCRIPTION
## Summary by Sourcery

Add a close_window method to encapsulate the cleanup process for the settings window, replacing direct calls to settings_window.destroy with this method to ensure proper unbinding of events and clearing of settings entries.

New Features:
- Introduce a close_window method to handle the cleanup of the settings window.

Enhancements:
- Replace direct calls to settings_window.destroy with the new close_window method for better encapsulation and cleanup.