### PR TITLE
Bug Fix: undefined variable error while generating notes

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -635,7 +635,7 @@ def generate_note(formatted_message):
                         medical_note = send_text_to_chatgpt(f"{app_settings.AISCRIBE} {formatted_message} {app_settings.AISCRIBE2}")
 
                         if app_settings.editable_settings["Use Post-Processing"]:
-                            post_processed_note = send_text_to_chatgpt(f"{app_settings.editable_settings['Post-Processing']}\nFacts:{list_of_facts}\nNotes:{medical_note}")
+                            post_processed_note = send_text_to_chatgpt(f"{app_settings.editable_settings['Post-Processing']}\nNotes:{medical_note}")
                             update_gui_with_response(post_processed_note)
                         else:
                             update_gui_with_response(medical_note)


### PR DESCRIPTION
Error in Generate notes

Pre-processing: off
Post-processing: on

Error: Undefined variable list_of_facts

## Summary by Sourcery

Bug Fixes:
- Fix undefined variable error by removing the reference to 'list_of_facts' in the post-processing step of note generation.