### PR TITLE
Create FreeScribe dir in user data dir

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ MAIN_SCRIPT="src/FreeScribe.client/client.py"
 ICON_PATH="src/FreeScribe.client/assets/logo.ico"
 
 # Run PyInstaller to create the standalone executable
-pyinstaller --additional-hooks-dir=./scripts/hooks --add-data "./src/FreeScribe.client/whisper-assets:whisper/assets" --add-data "./src/FreeScribe.client/markdown:markdown" --add-data "./src/FreeScribe.client/assets:assets" --name "$EXECUTABLE_NAME" --icon="$ICON_PATH" --noconsole "$MAIN_SCRIPT"
+pyinstaller --additional-hooks-dir=./scripts/hooks --add-data "./src/FreeScribe.client/whisper-assets:whisper/assets" --add-data "./src/FreeScribe.client/markdown:markdown" --add-data "./src/FreeScribe.client/assets:assets" --name "$EXECUTABLE_NAME" --icon="$ICON_PATH" "$MAIN_SCRIPT" --noconsole --noconfirm
 
 # Print a message indicating that the build is complete
 echo "Build complete. Executable created: dist/$EXECUTABLE_NAME"

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Ensure the script exits if any command fails
+set -e
+
+# Define the name of the executable and the main Python script
+EXECUTABLE_NAME="freescribe-client"
+MAIN_SCRIPT="src/FreeScribe.client/client.py"
+ICON_PATH="src/FreeScribe.client/assets/logo.ico"
+
+# Run PyInstaller to create the standalone executable
+pyinstaller --additional-hooks-dir=./scripts/hooks --add-data "./src/FreeScribe.client/whisper-assets:whisper/assets" --add-data "./src/FreeScribe.client/markdown:markdown" --add-data "./src/FreeScribe.client/assets:assets" --name "$EXECUTABLE_NAME" --icon="$ICON_PATH" --noconsole "$MAIN_SCRIPT"
+
+# Print a message indicating that the build is complete
+echo "Build complete. Executable created: dist/$EXECUTABLE_NAME"

--- a/src/FreeScribe.client/utils/file_utils.py
+++ b/src/FreeScribe.client/utils/file_utils.py
@@ -29,8 +29,11 @@ def get_resource_path(filename: str) -> str:
         freescribe_dir = os.path.join(base, 'FreeScribe')
         
         # Check if the FreeScribe directory exists, if not, create it
-        if not os.path.exists(freescribe_dir):
-            os.makedirs(freescribe_dir)
+        try:
+            if not os.path.exists(freescribe_dir):
+                os.makedirs(freescribe_dir)
+        except OSError as e:
+            raise RuntimeError(f"Failed to create FreeScribe directory: {e}")
         
         return os.path.join(freescribe_dir, filename)
     else:

--- a/src/FreeScribe.client/utils/file_utils.py
+++ b/src/FreeScribe.client/utils/file_utils.py
@@ -26,7 +26,13 @@ def get_resource_path(filename: str) -> str:
     """
     if hasattr(sys, '_MEIPASS'):
         base = _get_user_data_dir()
-        return os.path.join(base, 'FreeScribe', filename)
+        freescribe_dir = os.path.join(base, 'FreeScribe')
+        
+        # Check if the FreeScribe directory exists, if not, create it
+        if not os.path.exists(freescribe_dir):
+            os.makedirs(freescribe_dir)
+        
+        return os.path.join(freescribe_dir, filename)
     else:
         return os.path.abspath(filename)
 


### PR DESCRIPTION
**Issue** #92

## Summary by Sourcery

Ensure the FreeScribe directory is created in the user data directory if it does not exist and add a build script to create a standalone executable for the FreeScribe client using PyInstaller.

Enhancements:
- Ensure the FreeScribe directory is created in the user data directory if it does not exist.

Build:
- Add a build script using PyInstaller to create a standalone executable for the FreeScribe client.