### PR TITLE
remove freescribe completely on uninstall

### DIFF
--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -150,11 +150,9 @@ SectionEnd
 
 ; Define the uninstaller section
 Section "Uninstall"
-    ; Remove files
-    Delete "$INSTDIR\*"
 
-    ; Remove the installation directory
-    RMDir "$INSTDIR"
+    ; Remove the installation directory and all its contents
+    RMDir /r "$INSTDIR"
 
     ; Remove the start menu shortcut
     Delete "$SMPROGRAMS\FreeScribe\FreeScribe.lnk"


### PR DESCRIPTION
**issue** #91

## Summary by Sourcery

Enhancements:
- Ensure complete removal of FreeScribe by deleting the installation directory and all its contents during uninstallation.