### PR TITLE
Remove SSL settings and refactor certificate verification

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -37,10 +37,6 @@ class SettingsWindow():
 
     Attributes
     ----------
-    SSL_ENABLE : str
-        Whether SSL is enabled ('1' for enabled, '0' for disabled).
-    SSL_SELFCERT : str
-        Whether self-signed certificates are used ('1' for enabled, '0' for disabled).
     OPENAI_API_KEY : str
         The API key for OpenAI integration.
     AISCRIBE : str
@@ -61,14 +57,12 @@ class SettingsWindow():
     save_settings_to_file():
         Saves the current settings to a JSON file.
     save_settings(openai_api_key, aiscribe_text, aiscribe2_text, 
-                  settings_window, ssl_enable, ssl_selfcert, api_style, preset):
+                  settings_window, api_style, preset):
         Saves the current settings, including API keys, IP addresses, and user-defined parameters.
     load_aiscribe_from_file():
         Loads the first AI Scribe text from a file.
     load_aiscribe2_from_file():
         Loads the second AI Scribe text from a file.
-    build_url(ip, port):
-        Constructs a URL based on IP, port, and SSL settings.
     clear_settings_file(settings_window):
         Clears the content of settings files and closes the settings window.
     """
@@ -76,8 +70,7 @@ class SettingsWindow():
     def __init__(self):
         """Initializes the ApplicationSettings with default values."""
 
-        self.SSL_ENABLE = "0"
-        self.SSL_SELFCERT = "1"
+
         self.OPENAI_API_KEY = "None"
         self.API_STYLE = "OpenAI"
         self.main_window = None
@@ -95,10 +88,12 @@ class SettingsWindow():
             "Whisper Model",
             "Local Whisper",
             "Real Time",
+            "S2T Server Self-Signed Certificates",
         ]
         self.llm_settings = [
             "Model Endpoint",
             "Use Local LLM",
+            "AI Server Self-Signed Certificates",
         ]
 
         self.advanced_settings = [
@@ -173,6 +168,8 @@ class SettingsWindow():
             "Enable Scribe Template": False,
             "Use Pre-Processing": True,
             "Use Post-Processing": False, # Disabled for now causes unexcepted behaviour
+            "AI Server Self-Signed Certificates": False,
+            "S2T Server Self-Signed Certificates": False,
             "Pre-Processing": "Please break down the conversation into a list of facts. Take the conversation and transform it to a easy to read list:\n\n",
             "Post-Processing": "\n\nPlease check your work from the list of facts and ensure the SOAP note is accurate based on the information. Please ensure the data is accurate in regards to the list of facts. Then please provide the revised SOAP Note:",
         }
@@ -242,10 +239,8 @@ class SettingsWindow():
                     settings = json.load(file)
                 except json.JSONDecodeError:
                     print("Error loading settings file. Using default settings.")
-                    return self.OPENAI_API_KEY, self.SSL_ENABLE, self.SSL_SELFCERT, self.API_STYLE
+                    return self.OPENAI_API_KEY, self.API_STYLE
 
-                self.SSL_ENABLE = settings.get("ssl_enable", self.SSL_ENABLE)
-                self.SSL_SELFCERT = settings.get("ssl_selfcert", self.SSL_SELFCERT)
                 self.OPENAI_API_KEY = settings.get("openai_api_key", self.OPENAI_API_KEY)
                 self.API_STYLE = settings.get("api_style", self.API_STYLE)
                 loaded_editable_settings = settings.get("editable_settings", {})
@@ -260,10 +255,10 @@ class SettingsWindow():
                     self.main_window.create_scribe_template()
 
 
-                return self.OPENAI_API_KEY, self.SSL_ENABLE, self.SSL_SELFCERT, self.API_STYLE
+                return self.OPENAI_API_KEY, self.API_STYLE
         except FileNotFoundError:
             print("Settings file not found. Using default settings.")
-            return self.OPENAI_API_KEY, self.SSL_ENABLE, self.SSL_SELFCERT, self.API_STYLE
+            return self.OPENAI_API_KEY, self.API_STYLE
 
     def save_settings_to_file(self):
         """
@@ -278,15 +273,13 @@ class SettingsWindow():
         settings = {
             "openai_api_key": self.OPENAI_API_KEY,
             "editable_settings": self.editable_settings,
-            "ssl_enable": str(self.SSL_ENABLE),
-            "ssl_selfcert": str(self.SSL_SELFCERT),
             "api_style": self.API_STYLE
         }
         with open(get_resource_path('settings.txt'), 'w') as file:
             json.dump(settings, file)
 
     def save_settings(self, openai_api_key, aiscribe_text, aiscribe2_text, settings_window,
-                      ssl_enable, ssl_selfcert, api_style, silence_cutoff):
+                      api_style, silence_cutoff):
         """
         Save the current settings, including IP addresses, API keys, and user-defined parameters.
 
@@ -297,12 +290,8 @@ class SettingsWindow():
         :param str aiscribe_text: The text for the first AI Scribe.
         :param str aiscribe2_text: The text for the second AI Scribe.
         :param tk.Toplevel settings_window: The settings window instance to be destroyed after saving.
-        :param int ssl_enable: Flag indicating whether SSL is enabled.
-        :param int ssl_selfcert: Flag indicating whether to use a self-signed certificate.
         :param str api_style: The style of API being used.
         """
-        self.SSL_ENABLE = ssl_enable
-        self.SSL_SELFCERT = ssl_selfcert
         self.OPENAI_API_KEY = openai_api_key
         self.API_STYLE = api_style
 
@@ -350,45 +339,6 @@ class SettingsWindow():
         except FileNotFoundError:
             return None
 
-    def build_url(self, ip, port):
-        """
-        Build a URL string based on the IP address, port, and SSL settings.
-
-        If SSL is enabled (`SSL_ENABLE` is set to "1"), the method returns a URL
-        with the `https` scheme, otherwise, it returns a URL with the `http` scheme.
-        
-        The method also handles the case of self-signed SSL certificates based on
-        the `SSL_SELFCERT` setting.
-
-        Parameters
-        ----------
-        ip : str
-            The IP address of the server.
-        port : str
-            The port number of the server.
-
-        Returns
-        -------
-        str
-            A fully formed URL for either `https` or `http` depending on the SSL settings.
-
-        Prints
-        ------
-        If SSL is enabled, prints a message indicating that SSL/TLS connections are enabled.
-        If self-signed certificates are allowed, it prints a warning about trusting self-signed certificates.
-        If SSL is disabled, prints a message indicating that unencrypted connections will be used.
-        """
-
-        if str(self.SSL_ENABLE) == "1":
-            print("Encrypted SSL/TLS connections are ENABLED between client and server.")
-            if str(self.SSL_SELFCERT) == "1":
-                print("...Self-signed SSL certificates are ALLOWED in Settings...\n...You may disregard subsequent log Warning if you are trusting self-signed certificates from server...")
-            else:
-                print("...Self-signed SSL certificates are DISABLED in Settings...\n...Trusted/Verified SSL certificates must be used on server, otherwise SSL connection will fail...")
-            return f"https://{ip}:{port}"
-        else:
-            print("UNENCRYPTED http connections are being used between Client and Whisper/Kobbold server...")
-            return f"http://{ip}:{port}"
   
     def clear_settings_file(self, settings_window):
         """
@@ -441,7 +391,8 @@ class SettingsWindow():
         }
 
         try:
-            response = requests.get(self.editable_settings["Model Endpoint"] + "/models", headers=headers, timeout=2.0, verify=not (self.SSL_SELFCERT and self.SSL_ENABLE))
+            verify = True if self.editable_settings["AI Server Self-Signed Certificates"] is True else False
+            response = requests.get(self.editable_settings["Model Endpoint"] + "/models", headers=headers, timeout=2.0, verify=verify)
             response.raise_for_status()  # Raise an error for bad responses
             models = response.json().get("data", [])  # Extract the 'data' field
             available_models = [model["id"] for model in models]

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -391,7 +391,7 @@ class SettingsWindow():
         }
 
         try:
-            verify = True if self.editable_settings["AI Server Self-Signed Certificates"] is True else False
+            verify = not self.editable_settings["AI Server Self-Signed Certificates"]
             response = requests.get(self.editable_settings["Model Endpoint"] + "/models", headers=headers, timeout=2.0, verify=verify)
             response.raise_for_status()  # Raise an error for bad responses
             models = response.json().get("data", [])  # Extract the 'data' field

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -207,13 +207,6 @@ class SettingsWindowUI:
         self.api_dropdown.grid(row=left_row, column=1, columnspan=2, padx=0, pady=5, sticky="w")
         left_row += 1
 
-        # 4. Enable SSL (Right Column)
-        self.ssl_enable_var = tk.IntVar(value=int(self.settings.SSL_ENABLE))
-        tk.Label(right_frame, text="Enable SSL:").grid(row=right_row, column=0, padx=0, pady=5, sticky="w")
-        self.ssl_enable_checkbox = tk.Checkbutton(right_frame, variable=self.ssl_enable_var)
-        self.ssl_enable_checkbox.grid(row=right_row, column=1, columnspan=2, padx=0, pady=5, sticky="w")
-        right_row += 1
-
         # 5. Models (Left Column)
         tk.Label(left_frame, text="Models").grid(row=left_row, column=0, padx=0, pady=5, sticky="w")
         models_drop_down_options = []
@@ -242,19 +235,8 @@ class SettingsWindowUI:
 
         self.architecture_dropdown.grid(row=right_row, column=1, padx=0, pady=5, sticky="w")
 
-        
         right_row += 1
 
-        # # Restart Local Llm Button
-        # restart_llm_button = ttk.Button(right_frame, text="Restart LLM", width=15, command=lambda: self.restart_local_llm())
-
-        # 6. Self-Signed Cert (Right Column)
-        self.ssl_selfcert_var = tk.IntVar(value=int(self.settings.SSL_SELFCERT))
-        tk.Label(right_frame, text="Self-Signed Cert:").grid(row=right_row, column=0, padx=0, pady=5, sticky="w")
-        self.ssl_selfcert_checkbox = tk.Checkbutton(right_frame, variable=self.ssl_selfcert_var)
-        self.ssl_selfcert_checkbox.grid(row=right_row, column=1, columnspan=2, padx=0, pady=5, sticky="w")
-        right_row += 1
-        
         self.create_editable_settings_col(left_frame, right_frame, left_row, right_row, self.settings.llm_settings)
  
     def on_model_selection_change(self, event):
@@ -481,8 +463,6 @@ class SettingsWindowUI:
             self.aiscribe_text.get("1.0", "end-1c"), # end-1c removes the trailing newline
             self.aiscribe2_text.get("1.0", "end-1c"), # end-1c removes the trailing newline
             self.settings_window,
-            self.ssl_enable_var.get(),
-            self.ssl_selfcert_var.get(),
             self.api_dropdown.get(),
             self.cutoff_slider.threshold / 32768,
         )

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -230,7 +230,7 @@ def realtime_text():
                                 "Authorization": "Bearer "+app_settings.editable_settings["Whisper Server API Key"]
                             }
 
-                            verify = False if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else True
+                            verify = not app_settings.editable_settings["S2T Server Self-Signed Certificates"]
                             response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers,files=files, verify=verify)
                             
                             if response.status_code == 200:
@@ -420,7 +420,7 @@ def send_audio_to_server():
             }
 
             try:
-                verify = False if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else True
+                verify = not app_settings.editable_settings["S2T Server Self-Signed Certificates"]
 
                 # Send the request without verifying the SSL certificate
                 response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers, files=files, verify=verify)
@@ -554,7 +554,7 @@ def send_text_to_api(edited_text):
             app_settings.editable_settings["Model Endpoint"] = app_settings.editable_settings["Model Endpoint"][:-1]
 
         if app_settings.API_STYLE == "OpenAI":
-            verify = False if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else True
+            verify = not app_settings.editable_settings["AI Server Self-Signed Certificates"]
             response = requests.post(app_settings.editable_settings["Model Endpoint"]+"/chat/completions", headers=headers, json=payload, verify=verify)
 
             response.raise_for_status()
@@ -564,7 +564,7 @@ def send_text_to_api(edited_text):
         elif app_settings.API_STYLE == "KoboldCpp":
             prompt = get_prompt(edited_text)
 
-            verify = False if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else True
+            verify = not app_settings.editable_settings["AI Server Self-Signed Certificates"]
             response = requests.post(app_settings.editable_settings["Model Endpoint"] + "/api/v1/generate", json=prompt, verify=verify)
 
             if response.status_code == 200:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -230,7 +230,7 @@ def realtime_text():
                                 "Authorization": "Bearer "+app_settings.editable_settings["Whisper Server API Key"]
                             }
 
-                            verify = True if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else False
+                            verify = False if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else True
                             response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers,files=files, verify=verify)
                             
                             if response.status_code == 200:
@@ -420,7 +420,7 @@ def send_audio_to_server():
             }
 
             try:
-                verify = True if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else False
+                verify = False if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else True
 
                 # Send the request without verifying the SSL certificate
                 response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers, files=files, verify=verify)
@@ -554,7 +554,7 @@ def send_text_to_api(edited_text):
             app_settings.editable_settings["Model Endpoint"] = app_settings.editable_settings["Model Endpoint"][:-1]
 
         if app_settings.API_STYLE == "OpenAI":
-            verify = True if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else False
+            verify = False if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else True
             response = requests.post(app_settings.editable_settings["Model Endpoint"]+"/chat/completions", headers=headers, json=payload, verify=verify)
 
             response.raise_for_status()
@@ -564,7 +564,7 @@ def send_text_to_api(edited_text):
         elif app_settings.API_STYLE == "KoboldCpp":
             prompt = get_prompt(edited_text)
 
-            verify = True if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else False
+            verify = False if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else True
             response = requests.post(app_settings.editable_settings["Model Endpoint"] + "/api/v1/generate", json=prompt, verify=verify)
 
             if response.status_code == 200:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -236,6 +236,8 @@ def realtime_text():
                                 if response.status_code == 200:
                                     text = response.json()['text']
                                     update_gui(text)
+                                else:
+                                    update_gui(f"Error (HTTP Status {response.status_code}): {response.text}")
                             except Exception as e:
                                 update_gui(f"Error: {e}")
                             finally:
@@ -446,6 +448,13 @@ def send_audio_to_server():
 
                     # Send the transcribed text and receive a response
                     send_and_receive()
+                else:
+                    # Display an error message to the user
+                    user_input.scrolled_text.configure(state='normal')
+                    user_input.scrolled_text.delete("1.0", tk.END)
+                    user_input.scrolled_text.insert(tk.END, f"An error occurred (HTTP Status {response.status_code}): {response.text}")
+                    user_input.scrolled_text.configure(state='disabled')
+
 
             except Exception as e:
                 # log error message

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -230,10 +230,9 @@ def realtime_text():
                                 "Authorization": "Bearer "+app_settings.editable_settings["Whisper Server API Key"]
                             }
 
-                            if str(app_settings.SSL_ENABLE) == "1" and str(app_settings.SSL_SELFCERT) == "1":
-                                response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers,files=files, verify=False)
-                            else:
-                                response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers,files=files)
+                            verify = True if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else False
+                            response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers,files=files, verify=verify)
+                            
                             if response.status_code == 200:
                                 text = response.json()['text']
                                 update_gui(text)
@@ -421,14 +420,10 @@ def send_audio_to_server():
             }
 
             try:
-                response = None
-                # Check for SSL and self-signed certificate settings
-                if str(app_settings.SSL_ENABLE) == "1" and str(app_settings.SSL_SELFCERT) == "1":
-                    # Send the request without verifying the SSL certificate
-                    response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers, files=files, verify=False)
-                else:
-                    # Send the request with the audio file and headers/authorization
-                    response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers, files=files)
+                verify = True if app_settings.editable_settings["S2T Server Self-Signed Certificates"] is True else False
+
+                # Send the request without verifying the SSL certificate
+                response = requests.post(app_settings.editable_settings["Whisper Endpoint"], headers=headers, files=files, verify=verify)
 
                 # On successful response (status code 200)
                 if response.status_code == 200:
@@ -559,11 +554,8 @@ def send_text_to_api(edited_text):
             app_settings.editable_settings["Model Endpoint"] = app_settings.editable_settings["Model Endpoint"][:-1]
 
         if app_settings.API_STYLE == "OpenAI":
-            response = requests.Response
-            if str(app_settings.SSL_SELFCERT) == "1" and str(app_settings.SSL_ENABLE) == "1":
-                response = requests.post(app_settings.editable_settings["Model Endpoint"]+"/chat/completions", headers=headers, json=payload, verify=False)
-            else:
-                response = requests.post(app_settings.editable_settings["Model Endpoint"]+"/chat/completions", headers=headers, json=payload)
+            verify = True if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else False
+            response = requests.post(app_settings.editable_settings["Model Endpoint"]+"/chat/completions", headers=headers, json=payload, verify=verify)
 
             response.raise_for_status()
             response_data = response.json()
@@ -571,10 +563,10 @@ def send_text_to_api(edited_text):
             return response_text
         elif app_settings.API_STYLE == "KoboldCpp":
             prompt = get_prompt(edited_text)
-            if str(app_settings.SSL_ENABLE) == "1" and str(app_settings.SSL_SELFCERT) == "1":
-                response = requests.post(app_settings.editable_settings["Model Endpoint"] + "/api/v1/generate", json=prompt, verify=False)
-            else:
-                response = requests.post(app_settings.editable_settings["Model Endpoint"] + "/api/v1/generate", json=prompt)
+
+            verify = True if app_settings.editable_settings["AI Server Self-Signed Certificates"] is True else False
+            response = requests.post(app_settings.editable_settings["Model Endpoint"] + "/api/v1/generate", json=prompt, verify=verify)
+
             if response.status_code == 200:
                 results = response.json()['results']
                 response_text = results[0]['text']


### PR DESCRIPTION
Issue: #111 

## Summary by Sourcery

Enhancements:
- Refactor certificate verification logic to use a boolean flag for self-signed certificates instead of separate SSL settings.

## Summary by Sourcery

Enhancements:
- Refactor certificate verification logic to use a single 'verify' flag based on self-signed certificate settings.