### PR TITLE
Take Arch Type as CLI params in silent mode

### DIFF
--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -1,5 +1,6 @@
 !include "MUI2.nsh"
 !include "LogicLib.nsh"
+!include "FileFunc.nsh"
 
 ; Define the name of the installer
 OutFile "..\dist\FreeScribeInstaller.exe"
@@ -126,6 +127,18 @@ Function .onInit
         MessageBox MB_OK "FreeScribe is currently running. Please close the application before installing. Once closed please restart the installer."
         Abort
     ${EndIf}
+
+    IfSilent SILENT_MODE NOT_SILENT_MODE
+
+    SILENT_MODE:
+        ${GetParameters} $R0
+        ; Check for custom parameters
+        ${GetOptions} $R0 "/ARCH=" $R1
+        ${If} $R1 != ""
+            StrCpy $SELECTED_OPTION $R1
+        ${EndIf}
+        
+    NOT_SILENT_MODE:
 FunctionEnd
 
 Function CleanUninstall
@@ -278,6 +291,7 @@ FunctionEnd
 Function InsfilesPageLeave
     SetAutoClose true
 FunctionEnd
+
 
 ; Define installer pages
 !insertmacro MUI_PAGE_LICENSE ".\assets\License.txt"


### PR DESCRIPTION
**Issue**: #155

## Summary by Sourcery

Add support for specifying the architecture type as a command-line parameter when running the installer in silent mode, and include FileFunc.nsh for additional file handling capabilities.

New Features:
- Add support for passing architecture type as a command-line parameter in silent mode.

Enhancements:
- Include FileFunc.nsh to utilize file-related functions in the installer script.