### PR TITLE
Disable non-basic ui elements on start record, and remove menu bar from minimized view

### DIFF
--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -219,7 +219,21 @@ class MainWindowUI:
             help_menu = self.menu_bar.nametowidget('Help')
             if help_menu is not None:
                 help_menu.destroy()
+
+    def disable_settings_menu(self):
+        """
+        Disable the Settings menu.
+        """
+        if self.menu_bar is not None:
+            self.menu_bar.entryconfig("Settings", state="disabled")  # Disables the entire Settings menu
     
+    def enable_settings_menu(self):
+        """
+        Enable the Settings menu.
+        """
+        if self.menu_bar is not None:
+            self.menu_bar.entryconfig("Settings", state="normal")
+
     def _show_md_content(self, file_path: str, title: str, show_checkbox: bool = False):
         """
         Private method to display help/about information.

--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -154,6 +154,18 @@ class MainWindowUI:
             self.root.after_cancel(self.current_container_status_check_id)
             self.current_container_status_check_id = None
 
+    def toggle_menu_bar(self, enable: bool):
+        """
+        Enable or disable the menu bar.
+
+        :param enable: True to enable the menu bar, False to disable it.
+        :type enable: bool
+        """
+        if enable:
+            self._create_menu_bar()
+        else:
+            self._destroy_menu_bar()
+
     def _create_menu_bar(self):
         """
         Private method to create menu bar.
@@ -165,11 +177,32 @@ class MainWindowUI:
         self._create_settings_menu()
         self._create_help_menu()
 
+    def _destroy_menu_bar(self):
+        """
+        Private method to destroy the menu bar.
+        Destroy the menu bar if it exists.
+        """
+        if self.menu_bar is not None:
+            self.menu_bar.destroy()
+            self.menu_bar = None
+            self._destroy_settings_menu()
+            self._destroy_help_menu()
+
     def _create_settings_menu(self):
         # Add Settings menu
         setting_menu = tk.Menu(self.menu_bar, tearoff=0)
         self.menu_bar.add_cascade(label="Settings", menu=setting_menu)
         setting_menu.add_command(label="Settings", command=self.setting_window.open_settings_window)
+
+    def _destroy_settings_menu(self):
+        """
+        Private method to destroy the Settings menu.
+        Destroy the Settings menu if it exists.
+        """
+        if self.menu_bar is not None:
+            setting_menu = self.menu_bar.nametowidget('Settings')
+            if setting_menu is not None:
+                setting_menu.destroy()
 
     def _create_help_menu(self):
         # Add Help menu
@@ -177,6 +210,15 @@ class MainWindowUI:
         self.menu_bar.add_cascade(label="Help", menu=help_menu)
         help_menu.add_command(label="About", command=lambda: self._show_md_content(get_file_path('markdown','help','about.md'), 'About'))
 
+    def _destroy_help_menu(self):
+        """
+        Private method to destroy the Help menu.
+        Destroy the Help menu if it exists.
+        """
+        if self.menu_bar is not None:
+            help_menu = self.menu_bar.nametowidget('Help')
+            if help_menu is not None:
+                help_menu.destroy()
     
     def _show_md_content(self, file_path: str, title: str, show_checkbox: bool = False):
         """

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -313,13 +313,13 @@ def toggle_recording():
         is_audio_processing_realtime_canceled.clear()
         is_audio_processing_whole_canceled.clear()
 
-    print(is_paused)
     if is_paused:
         toggle_pause()
 
     realtime_thread = threaded_realtime_text()
 
     if not is_recording:
+        disable_recording_ui_elements()
         REALTIME_TRANSCRIBE_THREAD_ID = realtime_thread.ident
         user_input.scrolled_text.configure(state='normal')
         user_input.scrolled_text.delete("1.0", tk.END)
@@ -342,6 +342,7 @@ def toggle_recording():
         
         start_flashing()
     else:
+        enable_recording_ui_elements()
         is_recording = False
         if recording_thread.is_alive():
             recording_thread.join()  # Ensure the recording thread is terminated
@@ -390,6 +391,24 @@ def toggle_recording():
             mic_button.config(bg=DEFAULT_BUTTON_COLOUR, text="Start\nRecording")
         elif current_view == "minimal":
             mic_button.config(bg=DEFAULT_BUTTON_COLOUR, text="🎤")
+
+def disable_recording_ui_elements():
+    window.disable_settings_menu()
+    user_input.scrolled_text.configure(state='disabled')
+    send_button.config(state='disabled')
+    toggle_button.config(state='disabled')
+    upload_button.config(state='disabled')
+    response_display.scrolled_text.configure(state='disabled')
+    timestamp_listbox.config(state='disabled')
+
+def enable_recording_ui_elements():
+    window.enable_settings_menu()
+    user_input.scrolled_text.configure(state='normal')
+    send_button.config(state='normal')
+    toggle_button.config(state='normal')
+    upload_button.config(state='normal')
+    timestamp_listbox.config(state='normal')
+    
 
 def cancel_processing():
     """Cancels any ongoing audio processing.

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1016,6 +1016,8 @@ def set_full_view():
     switch_view_button.grid(row=1, column=7, pady=5, padx=0,sticky='nsew')
     blinking_circle_canvas.grid(row=1, column=8, padx=0,pady=5)
 
+    window.toggle_menu_bar(enable=True)
+
     # Reconfigure button styles and text
     mic_button.config(bg="red" if is_recording else DEFAULT_BUTTON_COLOUR,
                       text="Stop\nRecording" if is_recording else "Start\nRecording")
@@ -1089,6 +1091,8 @@ def set_minimal_view():
     switch_view_button.config(text="⬆️")  # Minimal view indicator
 
     blinking_circle_canvas.grid(row=0, column=3, pady=2, padx=2)
+
+    window.toggle_menu_bar(enable=False)
 
     # Update window properties for minimal view
     root.attributes('-topmost', True)


### PR DESCRIPTION
- Recording now disables unnecessary UI elements that can cause the program to error out.
- Removed settings button from minimized view as it was causing unexpected transparency behaviors. Also, it is not needed. 

Small demo: https://gyazo.com/938fd4a18c478123139ea178addb89eb