### PR TITLE
[Uninstaller/Installer] options remove settings

### DIFF
--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -294,15 +294,13 @@ Function InsfilesPageLeave
     SetAutoClose true
 FunctionEnd
 
-Function CreateUninstallPage
+Function RemoveConfigFilesPage
+    !insertmacro MUI_HEADER_TEXT "Remove Configuration Files" "Do you want to remove the configuration files (e.g., settings)?"
     nsDialogs::Create 1018
-    Pop $Dialog
-    ${If} $Dialog == error
+    Pop $0
+    ${If} $0 == error
         Abort
     ${EndIf}
-
-    ${NSD_CreateLabel} 0 0 100% 12u "Do you want to remove the configuration files (e.g., settings)?"
-    Pop $Label
 
     ${NSD_CreateCheckbox} 0 20u 100% 12u "Remove configuration files"
     Pop $REMOVE_CONFIG_CHECKBOX
@@ -310,10 +308,9 @@ Function CreateUninstallPage
     nsDialogs::Show
 FunctionEnd
 
-Function UninstallPageLeave
+Function RemoveConfigFilesPageLeave
     ${NSD_GetState} $REMOVE_CONFIG_CHECKBOX $REMOVE_CONFIG
 FunctionEnd
-
 
 ; Define installer pages
 !insertmacro MUI_PAGE_LICENSE ".\assets\License.txt"

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -26,7 +26,6 @@ Var /GLOBAL CPU_RADIO
 Var /GLOBAL NVIDIA_RADIO
 Var /GLOBAL SELECTED_OPTION
 Var /GLOBAL REMOVE_CONFIG_CHECKBOX
-Var /GLOBAL REMOVE_CONFIG
 
 Function Check_For_Old_Version_In_App_Data
     ; Check if the old version exists in AppData
@@ -218,6 +217,7 @@ SectionEnd
 
 ; Define the uninstaller section
 Section "Uninstall"
+    Call CreateRemoveConfigFilesPage
 
     ; Remove the installation directory and all its contents
     RMDir /r "$INSTDIR"
@@ -228,6 +228,12 @@ Section "Uninstall"
 
     ; Remove the uninstaller entry from the Control Panel
     Delete "$INSTDIR\Uninstall.exe"
+
+    ; Remove configuration files if the checkbox is selected
+    ${NSD_GetState} $REMOVE_CONFIG_CHECKBOX $0
+    ${If} $0 == ${BST_CHECKED}
+        RMDir /r "$APPDATA\FreeScribe"
+    ${EndIf}
     
     ; Show message when uninstallation is complete
     MessageBox MB_OK "FreeScribe has been successfully uninstalled."
@@ -294,7 +300,7 @@ Function InsfilesPageLeave
     SetAutoClose true
 FunctionEnd
 
-Function RemoveConfigFilesPage
+Function CreateRemoveConfigFilesPage
     !insertmacro MUI_HEADER_TEXT "Remove Configuration Files" "Do you want to remove the configuration files (e.g., settings)?"
     nsDialogs::Create 1018
     Pop $0
@@ -304,12 +310,9 @@ Function RemoveConfigFilesPage
 
     ${NSD_CreateCheckbox} 0 20u 100% 12u "Remove configuration files"
     Pop $REMOVE_CONFIG_CHECKBOX
+    ${NSD_SetState} $REMOVE_CONFIG_CHECKBOX ${BST_CHECKED}
 
     nsDialogs::Show
-FunctionEnd
-
-Function RemoveConfigFilesPageLeave
-    ${NSD_GetState} $REMOVE_CONFIG_CHECKBOX $REMOVE_CONFIG
 FunctionEnd
 
 ; Define installer pages
@@ -322,7 +325,6 @@ Page Custom CustomizeFinishPage RunApp
 
 ; Define the uninstaller pages
 !insertmacro MUI_UNPAGE_CONFIRM
-Page custom RemoveConfigFilesPage RemoveConfigFilesPageLeave
 !insertmacro MUI_UNPAGE_INSTFILES
 !insertmacro MUI_UNPAGE_FINISH
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -120,13 +120,15 @@ Function .onInstSuccess
 FunctionEnd
 
 Function CheckIfFreeScribeIsRunning
+    CheckIfFreeScribeIsRunning:
     nsExec::ExecToStack 'cmd /c tasklist /FI "IMAGENAME eq freescribe-client.exe" /NH | find /I "freescribe-client.exe" > nul'
     Pop $0 ; Return value
 
     ; Check if the process is running
     ${If} $0 == 0
-        MessageBox MB_OK "FreeScribe is currently running. Please close the application before installing. Once closed please restart the installer."
-        Abort
+        MessageBox MB_RETRYCANCEL "FreeScribe is currently running. Please close the application and try again." IDRETRY CheckIfFreeScribeIsRunning IDCANCEL abort
+        abort:
+            Abort
     ${EndIf}
 FunctionEnd
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -170,9 +170,9 @@ FunctionEnd
 
 Function CheckForOldConfig
     ; Check if the old version exists in AppData
-    IfFileExists "$APPDATA\FreeScribe\settings.txt" 0 OldConfigDoesNotExist
+    IfFileExists "$APPDATA\FreeScribe\settings.txt" 0 End
         ; Open Dialog to ask user if they want to uninstall the old version
-        MessageBox MB_YESNO|MB_ICONQUESTION "An old configuration file has been detected. Would you like to remove it?" IDYES RemoveOldConfig IDNO OldConfigDoesNotExist
+        MessageBox MB_YESNO|MB_ICONQUESTION "An old configuration file has been detected. Would you like to remove it?" IDYES RemoveOldConfig IDNO End
         RemoveOldConfig:
             ClearErrors
             ; Remove the old version executable
@@ -180,10 +180,9 @@ Function CheckForOldConfig
             ${If} ${Errors}
                 MessageBox MB_RETRYCANCEL "Unable to remove old configuration. Please close any applications using these files and try again." IDRETRY RemoveOldConfig IDCANCEL ConfigFilesFailed
             ${EndIf}
-    Goto End
+            Goto End
     ConfigFilesFailed:
         MessageBox MB_OK|MB_ICONEXCLAMATION "Old configuration files could not be removed. Proceeding with installation."
-    OldConfigDoesNotExist:
     End:
 FunctionEnd
 
@@ -273,8 +272,6 @@ Section "Uninstall"
 
     ConfigFilesFailed:
         MessageBox MB_OK|MB_ICONEXCLAMATION "FreeScribe has been successfully uninstalled, but the configuration files could not be removed. Please close any applications using these files and try again."
-        Abort
-
     EndUninstall:
 SectionEnd
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -26,6 +26,7 @@ Var /GLOBAL CPU_RADIO
 Var /GLOBAL NVIDIA_RADIO
 Var /GLOBAL SELECTED_OPTION
 Var /GLOBAL REMOVE_CONFIG_CHECKBOX
+Var /GLOBAL REMOVE_CONFIG
 
 Function Check_For_Old_Version_In_App_Data
     ; Check if the old version exists in AppData
@@ -229,8 +230,6 @@ SectionEnd
 
 ; Define the uninstaller section
 Section "Uninstall"
-    Call un.CreateRemoveConfigFilesPage
-
     ; Remove the installation directory and all its contents
     RMDir /r "$INSTDIR"
 
@@ -242,8 +241,8 @@ Section "Uninstall"
     Delete "$INSTDIR\Uninstall.exe"
 
     ; Remove configuration files if the checkbox is selected
-    ${NSD_GetState} $REMOVE_CONFIG_CHECKBOX $0
-    ${If} $0 == ${BST_CHECKED}
+    MessageBox MB_OK "$REMOVE_CONFIG ${BST_CHECKED}"
+    ${If} $REMOVE_CONFIG == ${BST_CHECKED}
         RMDir /r "$APPDATA\FreeScribe"
     ${EndIf}
     
@@ -314,8 +313,10 @@ FunctionEnd
 
 Function un.CreateRemoveConfigFilesPage
     !insertmacro MUI_HEADER_TEXT "Remove Configuration Files" "Do you want to remove the configuration files (e.g., settings)?"
+    
     nsDialogs::Create 1018
     Pop $0
+
     ${If} $0 == error
         Abort
     ${EndIf}
@@ -325,6 +326,10 @@ Function un.CreateRemoveConfigFilesPage
     ${NSD_SetState} $REMOVE_CONFIG_CHECKBOX ${BST_CHECKED}
 
     nsDialogs::Show
+FunctionEnd
+
+Function un.RemoveConfigFilesPageLeave
+    ${NSD_GetState} $REMOVE_CONFIG_CHECKBOX $REMOVE_CONFIG
 FunctionEnd
 
 ; Define installer pages
@@ -337,6 +342,7 @@ Page Custom CustomizeFinishPage RunApp
 
 ; Define the uninstaller pages
 !insertmacro MUI_UNPAGE_CONFIRM
+UninstPage custom un.CreateRemoveConfigFilesPage un.RemoveConfigFilesPageLeave
 !insertmacro MUI_UNPAGE_INSTFILES
 !insertmacro MUI_UNPAGE_FINISH
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -165,8 +165,12 @@ Function CheckForOldConfig
         ; Open Dialog to ask user if they want to uninstall the old version
         MessageBox MB_YESNO|MB_ICONQUESTION "An old configuration file has been detected. Would you like to remove it?" IDYES RemoveOldConfig IDNO OldConfigDoesNotExist
         RemoveOldConfig:
+            ClearErrors
             ; Remove the old version executable
             RMDir /r "$APPDATA\FreeScribe"
+            ${If} ${Errors}
+                MessageBox MB_OK|MB_ICONEXCLAMATION "Unable to remove old configuration. Please close any applications using these files and try again."
+            ${EndIf}
     OldConfigDoesNotExist:
 FunctionEnd
 
@@ -243,7 +247,11 @@ Section "Uninstall"
     ; Remove configuration files if the checkbox is selected
     MessageBox MB_OK "$REMOVE_CONFIG ${BST_CHECKED}"
     ${If} $REMOVE_CONFIG == ${BST_CHECKED}
+        ClearErrors
         RMDir /r "$APPDATA\FreeScribe"
+        ${If} ${Errors}
+            MessageBox MB_OK|MB_ICONEXCLAMATION "Unable to remove old configuration. Please close any applications using these files and try again."
+        ${EndIf}
     ${EndIf}
     
     ; Show message when uninstallation is complete

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -229,7 +229,7 @@ SectionEnd
 
 ; Define the uninstaller section
 Section "Uninstall"
-    Call CreateRemoveConfigFilesPage
+    Call un.CreateRemoveConfigFilesPage
 
     ; Remove the installation directory and all its contents
     RMDir /r "$INSTDIR"
@@ -312,7 +312,7 @@ Function InsfilesPageLeave
     SetAutoClose true
 FunctionEnd
 
-Function CreateRemoveConfigFilesPage
+Function un.CreateRemoveConfigFilesPage
     !insertmacro MUI_HEADER_TEXT "Remove Configuration Files" "Do you want to remove the configuration files (e.g., settings)?"
     nsDialogs::Create 1018
     Pop $0

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -119,8 +119,7 @@ Function .onInstSuccess
     MessageBox MB_OK "Installation completed successfully! Please note upon first launch start time may be slow. Please wait for the program to open!"
 FunctionEnd
 
-; Checks on installer start
-Function .onInit
+Function CheckIfFreeScribeIsRunning
     nsExec::ExecToStack 'cmd /c tasklist /FI "IMAGENAME eq freescribe-client.exe" /NH | find /I "freescribe-client.exe" > nul'
     Pop $0 ; Return value
 
@@ -129,6 +128,14 @@ Function .onInit
         MessageBox MB_OK "FreeScribe is currently running. Please close the application before installing. Once closed please restart the installer."
         Abort
     ${EndIf}
+FunctionEnd
+
+Function Function un.onInit
+    Call CheckIfFreeScribeIsRunning
+FunctionEnd
+; Checks on installer start
+Function .onInit
+    Call CheckIfFreeScribeIsRunning
 
     IfSilent SILENT_MODE NOT_SILENT_MODE
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -177,7 +177,7 @@ Function CheckForOldConfig
     ; Check if the old version exists in AppData
     IfFileExists "$APPDATA\FreeScribe\settings.txt" 0 End
         ; Open Dialog to ask user if they want to uninstall the old version
-        MessageBox MB_YESNO|MB_ICONQUESTION "An old configuration file has been detected. Would you like to remove it?" IDYES RemoveOldConfig IDNO End
+        MessageBox MB_YESNO|MB_ICONQUESTION "An old configuration file has been detected. We recommend removing it to prevent conflict with new versions. Would you like to remove it?" IDYES RemoveOldConfig IDNO End
         RemoveOldConfig:
             ClearErrors
             ; Remove the old version executable

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -132,7 +132,7 @@ Function CheckIfFreeScribeIsRunning
     ${EndIf}
 FunctionEnd
 
-Function Function un.onInit
+Function un.onInit
     Call CheckIfFreeScribeIsRunning
 FunctionEnd
 ; Checks on installer start

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -119,7 +119,7 @@ Function .onInstSuccess
     MessageBox MB_OK "Installation completed successfully! Please note upon first launch start time may be slow. Please wait for the program to open!"
 FunctionEnd
 
-Function CheckIfFreeScribeIsRunning
+Function un.onInit
     CheckIfFreeScribeIsRunning:
     nsExec::ExecToStack 'cmd /c tasklist /FI "IMAGENAME eq freescribe-client.exe" /NH | find /I "freescribe-client.exe" > nul'
     Pop $0 ; Return value
@@ -131,13 +131,18 @@ Function CheckIfFreeScribeIsRunning
             Abort
     ${EndIf}
 FunctionEnd
-
-Function un.onInit
-    Call CheckIfFreeScribeIsRunning
-FunctionEnd
 ; Checks on installer start
 Function .onInit
-    Call CheckIfFreeScribeIsRunning
+    CheckIfFreeScribeIsRunning:
+    nsExec::ExecToStack 'cmd /c tasklist /FI "IMAGENAME eq freescribe-client.exe" /NH | find /I "freescribe-client.exe" > nul'
+    Pop $0 ; Return value
+
+    ; Check if the process is running
+    ${If} $0 == 0
+        MessageBox MB_RETRYCANCEL "FreeScribe is currently running. Please close the application and try again." IDRETRY CheckIfFreeScribeIsRunning IDCANCEL abort
+        abort:
+            Abort
+    ${EndIf}
 
     IfSilent SILENT_MODE NOT_SILENT_MODE
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -25,6 +25,8 @@ VIAddVersionKey "FileDescription" "FreeScribe Installer"
 Var /GLOBAL CPU_RADIO
 Var /GLOBAL NVIDIA_RADIO
 Var /GLOBAL SELECTED_OPTION
+Var /GLOBAL REMOVE_CONFIG_CHECKBOX
+Var /GLOBAL REMOVE_CONFIG
 
 Function Check_For_Old_Version_In_App_Data
     ; Check if the old version exists in AppData
@@ -292,6 +294,26 @@ Function InsfilesPageLeave
     SetAutoClose true
 FunctionEnd
 
+Function CreateUninstallPage
+    nsDialogs::Create 1018
+    Pop $Dialog
+    ${If} $Dialog == error
+        Abort
+    ${EndIf}
+
+    ${NSD_CreateLabel} 0 0 100% 12u "Do you want to remove the configuration files (e.g., settings)?"
+    Pop $Label
+
+    ${NSD_CreateCheckbox} 0 20u 100% 12u "Remove configuration files"
+    Pop $REMOVE_CONFIG_CHECKBOX
+
+    nsDialogs::Show
+FunctionEnd
+
+Function UninstallPageLeave
+    ${NSD_GetState} $REMOVE_CONFIG_CHECKBOX $REMOVE_CONFIG
+FunctionEnd
+
 
 ; Define installer pages
 !insertmacro MUI_PAGE_LICENSE ".\assets\License.txt"
@@ -303,6 +325,7 @@ Page Custom CustomizeFinishPage RunApp
 
 ; Define the uninstaller pages
 !insertmacro MUI_UNPAGE_CONFIRM
+Page custom RemoveConfigFilesPage RemoveConfigFilesPageLeave
 !insertmacro MUI_UNPAGE_INSTFILES
 !insertmacro MUI_UNPAGE_FINISH
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -158,9 +158,21 @@ Function CleanUninstall
     RMDir "$SMPROGRAMS\FreeScribe"
 FunctionEnd
 
+Function CheckForOldConfig
+    ; Check if the old version exists in AppData
+    IfFileExists "$APPDATA\FreeScribe\settings.txt" 0 OldConfigDoesNotExist
+        ; Open Dialog to ask user if they want to uninstall the old version
+        MessageBox MB_YESNO|MB_ICONQUESTION "An old configuration file has been detected. Would you like to remove it?" IDYES RemoveOldConfig IDNO OldConfigDoesNotExist
+        RemoveOldConfig:
+            ; Remove the old version executable
+            RMDir /r "$APPDATA\FreeScribe"
+    OldConfigDoesNotExist:
+FunctionEnd
+
 ; Define the section of the installer
 Section "MainSection" SEC01
     Call CleanUninstall
+    Call CheckForOldConfig
     ; Set output path to the installation directory
     SetOutPath "$INSTDIR"
 

--- a/scripts/install.nsi
+++ b/scripts/install.nsi
@@ -169,9 +169,13 @@ Function CheckForOldConfig
             ; Remove the old version executable
             RMDir /r "$APPDATA\FreeScribe"
             ${If} ${Errors}
-                MessageBox MB_OK|MB_ICONEXCLAMATION "Unable to remove old configuration. Please close any applications using these files and try again."
+                MessageBox MB_RETRYCANCEL "Unable to remove old configuration. Please close any applications using these files and try again." IDRETRY RemoveOldConfig IDCANCEL ConfigFilesFailed
             ${EndIf}
+    Goto End
+    ConfigFilesFailed:
+        MessageBox MB_OK|MB_ICONEXCLAMATION "Old configuration files could not be removed. Proceeding with installation."
     OldConfigDoesNotExist:
+    End:
 FunctionEnd
 
 ; Define the section of the installer
@@ -244,18 +248,25 @@ Section "Uninstall"
     ; Remove the uninstaller entry from the Control Panel
     Delete "$INSTDIR\Uninstall.exe"
 
-    ; Remove configuration files if the checkbox is selected
-    MessageBox MB_OK "$REMOVE_CONFIG ${BST_CHECKED}"
-    ${If} $REMOVE_CONFIG == ${BST_CHECKED}
-        ClearErrors
-        RMDir /r "$APPDATA\FreeScribe"
-        ${If} ${Errors}
-            MessageBox MB_OK|MB_ICONEXCLAMATION "Unable to remove old configuration. Please close any applications using these files and try again."
+    RemoveConfigFiles:
+        ; Remove configuration files if the checkbox is selected
+        ${If} $REMOVE_CONFIG == ${BST_CHECKED}
+            ClearErrors
+            RMDir /r "$APPDATA\FreeScribe"
+            ${If} ${Errors}
+                MessageBox MB_RETRYCANCEL "Unable to remove old configuration. Please close any applications using these files and try again." IDRETRY RemoveConfigFiles IDCANCEL ConfigFilesFailed
+            ${EndIf}
         ${EndIf}
-    ${EndIf}
     
     ; Show message when uninstallation is complete
     MessageBox MB_OK "FreeScribe has been successfully uninstalled."
+    Goto EndUninstall
+
+    ConfigFilesFailed:
+        MessageBox MB_OK|MB_ICONEXCLAMATION "FreeScribe has been successfully uninstalled, but the configuration files could not be removed. Please close any applications using these files and try again."
+        Abort
+
+    EndUninstall:
 SectionEnd
 
 # Variables for checkboxes


### PR DESCRIPTION
### Issue
- #181 
- #182 

### Screenshots
![image](https://github.com/user-attachments/assets/f6f7204a-6f5c-439f-91b1-c9fe7d48c926)
![image](https://github.com/user-attachments/assets/9850f6e2-ea18-4ad1-9fd5-3d3c46e76f50)

## Summary by Sourcery

Enhance the installer and uninstaller scripts by adding options to manage configuration files. Introduce a feature to check if FreeScribe is running before installation or uninstallation, prompting the user to close it. Add a checkbox in the uninstaller to allow users to remove configuration files, and implement a check for old configuration files during installation with an option to remove them.

New Features:
- Add a checkbox option in the uninstaller to remove configuration files during uninstallation.

Enhancements:
- Improve the installer and uninstaller scripts to check if FreeScribe is running and prompt the user to close it before proceeding.
- Add functionality to detect and optionally remove old configuration files during installation.