### PR TITLE
Load STT model on startup and refactor to global instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,7 @@ client.spec
 
 realtime.wav
 src/FreeScribe.client/models
-*.spec
+freescribe-client.spec
+freescribe-client-cpu.spec
+freescribe-client-nvidia.spec
 scripts/FreeScribeInstaller.exe

--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,5 @@ client.spec
 
 realtime.wav
 src/FreeScribe.client/models
-freescribe-client.spec
+*.spec
 scripts/FreeScribeInstaller.exe

--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -30,7 +30,7 @@ class MainWindowUI:
         self.app_settings = settings  # Application settings
         self.logic = mw.MainWindow(self.app_settings)  # Logic to control the container behavior
         self.scribe_template = None
-        self.setting_window = SettingsWindowUI(self.app_settings, self)  # Settings window
+        self.setting_window = SettingsWindowUI(self.app_settings, self, self.root)  # Settings window
         self.root.iconbitmap(get_file_path('assets','logo.ico'))
 
         self.current_docker_status_check_id = None  # ID for the current Docker status check

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -51,7 +51,7 @@ class SettingsWindowUI:
         advanced_settings_frame (tk.Frame): The scrollable frame for advanced settings.
     """
 
-    def __init__(self, settings, main_window):
+    def __init__(self, settings, main_window, root):
         """
         Initializes the SettingsWindowUI.
 
@@ -60,6 +60,7 @@ class SettingsWindowUI:
         """
         self.settings = settings
         self.main_window = main_window
+        self.root = root
         self.settings_window = None
         self.main_frame = None
         self.notebook = None
@@ -550,6 +551,10 @@ class SettingsWindowUI:
             # self.api_dropdown.get(),
             self.cutoff_slider.threshold / 32768,
         )
+
+        # if Local Whisper is selected, load the Whisper Model
+        if self.settings.editable_settings["Local Whisper"]:
+            self.root.event_generate("<<LoadSttModel>>")
 
         if self.settings.editable_settings["Use Docker Status Bar"] and self.main_window.docker_status_bar is None:
             self.main_window.create_docker_status_bar()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -242,6 +242,10 @@ def realtime_text():
                 if not is_silent(audio_buffer):
                     if app_settings.editable_settings["Local Whisper"] == True:
                         print("Local Real Time Whisper")
+                        if stt_local_model is None:
+                            update_gui("Local Whisper model not loaded. Please check your settings.")
+                            break
+
                         result = stt_local_model.transcribe(audio_buffer, fp16=False)
                         if not local_cancel_flag and not is_audio_processing_realtime_canceled.is_set():
                             update_gui(result['text'])

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1158,8 +1158,11 @@ def remove_placeholder(event, text_widget, placeholder_text="Text box"):
         text_widget.delete("1.0", "end")
         text_widget.config(fg='black')
 
-# to load the STT model on startup if it is enabled
 def load_stt_model(event=None):
+    thread = threading.Thread(target=_load_stt_model_thread, daemon=True)
+    thread.start()
+
+def _load_stt_model_thread():
     global stt_local_model
     model = app_settings.editable_settings["Whisper Model"].strip()
     # Create a loading window to display the loading message


### PR DESCRIPTION
If stt enabled/changes loading the new model on save

## Summary by Sourcery

Load the local speech-to-text model on application startup if enabled and refactor the application to use a global instance of the STT model for transcription tasks.

New Features:
- Load the local speech-to-text (STT) model on application startup if enabled.

Enhancements:
- Refactor the application to use a global instance of the STT model for transcription tasks.