### PR TITLE
Enhance STT reload logic and fix DebugWindow NoneType error

### DIFF
--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -44,13 +44,15 @@ class DualOutput:
                 DualOutput.buffer.append(formatted_message)
         else:
             DualOutput.buffer.append("\n")
-        self.original_stdout.write(message)
+        if self.original_stdout is not None:
+            self.original_stdout.write(message)
 
     def flush(self):
         """
         Flush the original stdout to ensure output is written immediately.
         """
-        self.original_stdout.flush()
+        if self.original_stdout is not None:
+            self.original_stdout.flush()
 
     @staticmethod
     def get_buffer_content():

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -552,6 +552,10 @@ class SettingsWindowUI:
         # save architecture
         self.settings.editable_settings["Architecture"] = self.architecture_dropdown.get()
 
+        # save the old whisper model to compare with the new model later
+        old_local_whisper = self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]
+        old_model = self.settings.editable_settings["Whisper Model"]
+
         self.settings.save_settings(
             self.openai_api_key_entry.get(),
             self.aiscribe_text.get("1.0", "end-1c"), # end-1c removes the trailing newline
@@ -561,9 +565,11 @@ class SettingsWindowUI:
             self.cutoff_slider.threshold / 32768,
         )
 
-        # if Local Whisper is selected, load the Whisper Model
+        # if Local Whisper is selected, compare the old model with the new model and reload the model if it has changed
         if self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]:
-            self.root.event_generate("<<LoadSttModel>>")
+            if old_local_whisper != self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] or old_model != \
+                    self.settings.editable_settings["Whisper Model"]:
+                self.root.event_generate("<<LoadSttModel>>")
 
         if self.settings.editable_settings["Use Docker Status Bar"] and self.main_window.docker_status_bar is None:
             self.main_window.create_docker_status_bar()

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -565,12 +565,6 @@ class SettingsWindowUI:
             self.cutoff_slider.threshold / 32768,
         )
 
-        # if Local Whisper is selected, compare the old model with the new model and reload the model if it has changed
-        if self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]:
-            if old_local_whisper != self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] or old_model != \
-                    self.settings.editable_settings["Whisper Model"]:
-                self.root.event_generate("<<LoadSttModel>>")
-
         if self.settings.editable_settings["Use Docker Status Bar"] and self.main_window.docker_status_bar is None:
             self.main_window.create_docker_status_bar()
         elif not self.settings.editable_settings["Use Docker Status Bar"] and self.main_window.docker_status_bar is not None:
@@ -583,6 +577,13 @@ class SettingsWindowUI:
 
         if close_window:
             self.close_window()
+
+        # loading the model after the window is closed to prevent the window from freezing
+        # if Local Whisper is selected, compare the old model with the new model and reload the model if it has changed
+        if self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] and (
+                old_local_whisper != self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] or old_model !=
+                self.settings.editable_settings["Whisper Model"]):
+            self.root.event_generate("<<LoadSttModel>>")
 
     def reset_to_default(self):
         """

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1157,7 +1157,8 @@ def set_minimal_view():
     if last_minimal_position:
         root.geometry(last_minimal_position)
 
-    root.attributes('-toolwindow', True)
+    # Enable to make the window a tool window (no taskbar icon)
+    # root.attributes('-toolwindow', True)
 
 def copy_text(widget):
     text = widget.get("1.0", tk.END)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1080,7 +1080,8 @@ def set_full_view():
     if last_full_position is not None:
         root.geometry(last_full_position)
 
-    root.attributes('-toolwindow', False)
+    # Disable to make the window an app(show taskbar icon)
+    # root.attributes('-toolwindow', False)
 
 
 def set_minimal_view():


### PR DESCRIPTION
## Summary by Sourcery

Enhance the settings saving process by comparing old and new Whisper model settings to conditionally reload the model, and fix a potential NoneType error in the DebugWindow by checking if original_stdout is not None before writing or flushing.

Bug Fixes:
- Fix potential NoneType error by checking if original_stdout is not None before writing or flushing.

Enhancements:
- Improve settings saving by comparing old and new Whisper model settings before reloading the model.