### PR TITLE
One instance

### DIFF
--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -10,6 +10,7 @@ import io
 import sys
 from datetime import datetime
 from collections import deque
+from utils.utils import window_has_running_instance
 
 class DualOutput:
     buffer = None
@@ -77,6 +78,8 @@ class DebugPrintWindow:
         :param parent: Parent tkinter window
         :type parent: tk.Tk or tk.Toplevel
         """
+        if window_has_running_instance("Debug Output"):
+            return
         self.window = tk.Toplevel(parent)
         self.window.title("Debug Output")
         self.window.geometry("650x450")

--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -10,7 +10,7 @@ import io
 import sys
 from datetime import datetime
 from collections import deque
-from utils.utils import window_has_running_instance
+from utils.utils import bring_to_front
 
 class DualOutput:
     buffer = None
@@ -78,9 +78,12 @@ class DebugPrintWindow:
         :param parent: Parent tkinter window
         :type parent: tk.Tk or tk.Toplevel
         """
-        if window_has_running_instance("Debug Output"):
+        self.parent = parent
+        if self.parent.debug_window_open:
+            bring_to_front("Debug Output")
             return
-        self.window = tk.Toplevel(parent)
+        self.parent.debug_window_open = True
+        self.window = tk.Toplevel(parent.root)
         self.window.title("Debug Output")
         self.window.geometry("650x450")
 
@@ -110,6 +113,9 @@ class DebugPrintWindow:
         copy_button = tk.Button(self.window, text="Copy to Clipboard", command=self._copy_to_clipboard)
         copy_button.pack(side=tk.LEFT, pady=10, padx=10)
 
+        # custom function to close the window
+        self.window.protocol("WM_DELETE_WINDOW", self.close_window)
+
         self.refresh_output()
 
     def _copy_to_clipboard(self):
@@ -135,3 +141,7 @@ class DebugPrintWindow:
             self.text_widget.delete("1.0", tk.END)
             self.text_widget.insert(tk.END, content)
             self.text_widget.see(top_line_index)
+
+    def close_window(self):
+        self.parent.debug_window_open = False
+        self.window.destroy()

--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -34,6 +34,7 @@ class MainWindowUI:
         self.scribe_template = None
         self.setting_window = SettingsWindowUI(self.app_settings, self, self.root)  # Settings window
         self.root.iconbitmap(get_file_path('assets','logo.ico'))
+        self.debug_window_open = False  # Flag to indicate if the debug window is open
 
         self.current_docker_status_check_id = None  # ID for the current Docker status check
         self.current_container_status_check_id = None  # ID for the current container status check
@@ -225,7 +226,7 @@ class MainWindowUI:
         # Add Help menu
         help_menu = tk.Menu(self.menu_bar, tearoff=0)
         self.menu_bar.add_cascade(label="Help", menu=help_menu)
-        help_menu.add_command(label="Debug Window", command=lambda: DebugPrintWindow(self.root))
+        help_menu.add_command(label="Debug Window", command=lambda: DebugPrintWindow(self))
         help_menu.add_command(label="About", command=lambda: self._show_md_content(get_file_path('markdown','help','about.md'), 'About'))
 
     def _destroy_help_menu(self):

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -44,7 +44,7 @@ import sys
 from UI.DebugWindow import DualOutput
 import traceback
 import sys
-from utils.utils import window_has_running_instance
+from utils.utils import window_has_running_instance, bring_to_front
 
 dual = DualOutput()
 sys.stdout = dual
@@ -59,6 +59,7 @@ if not window_has_running_instance(APP_NAME):
     root = tk.Tk()
     root.title(APP_NAME)
 else:
+    bring_to_front(APP_NAME)
     sys.exit(0)
 
 # settings logic

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -43,11 +43,6 @@ import ctypes
 import sys
 from UI.DebugWindow import DualOutput
 import traceback
-import fcntl
-
-if sys.platform == "win32":
-    import ctypes
-    from ctypes import wintypes
 
 dual = DualOutput()
 sys.stdout = dual
@@ -1305,37 +1300,3 @@ root.bind("<<LoadSttModel>>", load_stt_model)
 root.mainloop()
 
 p.terminate()
-
-def bring_to_front():
-    if sys.platform == "win32":
-        # Bring the existing application instance to the front on Windows
-        hwnd = ctypes.windll.user32.GetForegroundWindow()
-        ctypes.windll.user32.ShowWindow(hwnd, 5)  # SW_SHOW
-        ctypes.windll.user32.SetForegroundWindow(hwnd)
-    elif sys.platform == "darwin":
-        # Bring the existing application instance to the front on macOS
-        # TODO FOR MAC
-        pass
-
-if __name__ == "__main__":
-    lock_file = '/tmp/freescribe-client.lock' if sys.platform == "darwin" else 'freescribe-client.lock'
-    try:
-        # Try to create and lock the lock file
-        with open(lock_file, 'w') as f:
-            if sys.platform == "win32":
-                msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, 1)
-            elif sys.platform == "darwin":
-                # TODO FOR MAC
-                pass
-            # If successful, run the application
-            if sys.platform == "win32":
-                root = tk.Tk()
-                user_input = UserInput(root)  # Assuming UserInput is a class you have defined
-                user_input.pack()
-                root.mainloop()
-            elif sys.platform == "darwin":
-                # TODO FOR MAC
-                pass
-    except IOError:
-        # If the lock file is already locked, bring the existing instance to the front
-        bring_to_front()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -43,6 +43,11 @@ import ctypes
 import sys
 from UI.DebugWindow import DualOutput
 import traceback
+import fcntl
+
+if sys.platform == "win32":
+    import ctypes
+    from ctypes import wintypes
 
 dual = DualOutput()
 sys.stdout = dual
@@ -1300,3 +1305,37 @@ root.bind("<<LoadSttModel>>", load_stt_model)
 root.mainloop()
 
 p.terminate()
+
+def bring_to_front():
+    if sys.platform == "win32":
+        # Bring the existing application instance to the front on Windows
+        hwnd = ctypes.windll.user32.GetForegroundWindow()
+        ctypes.windll.user32.ShowWindow(hwnd, 5)  # SW_SHOW
+        ctypes.windll.user32.SetForegroundWindow(hwnd)
+    elif sys.platform == "darwin":
+        # Bring the existing application instance to the front on macOS
+        # TODO FOR MAC
+        pass
+
+if __name__ == "__main__":
+    lock_file = '/tmp/freescribe-client.lock' if sys.platform == "darwin" else 'freescribe-client.lock'
+    try:
+        # Try to create and lock the lock file
+        with open(lock_file, 'w') as f:
+            if sys.platform == "win32":
+                msvcrt.locking(f.fileno(), msvcrt.LK_NBLCK, 1)
+            elif sys.platform == "darwin":
+                # TODO FOR MAC
+                pass
+            # If successful, run the application
+            if sys.platform == "win32":
+                root = tk.Tk()
+                user_input = UserInput(root)  # Assuming UserInput is a class you have defined
+                user_input.pack()
+                root.mainloop()
+            elif sys.platform == "darwin":
+                # TODO FOR MAC
+                pass
+    except IOError:
+        # If the lock file is already locked, bring the existing instance to the front
+        bring_to_front()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -43,8 +43,8 @@ import ctypes
 import sys
 from UI.DebugWindow import DualOutput
 import traceback
-from ctypes import WinDLL
 import sys
+from utils.utils import window_has_running_instance
 
 dual = DualOutput()
 sys.stdout = dual
@@ -52,30 +52,11 @@ sys.stderr = dual
 
 APP_NAME = 'AI Medical Scribe'  # Application name
 
-# function to check if another instance of the application is already running
-def has_running_instance() -> bool:
-    """
-    Check if another instance of the application is already running.
-    Returns:
-        bool: True if another instance is running, False otherwise
-    """
-    U32DLL = WinDLL('user32')
-    # get the handle of any window matching 'APP_NAME'
-    hwnd = U32DLL.FindWindowW(None, APP_NAME)
-    print("Running instance check")
-    if hwnd:  # if a matching window exists...
-        print('Another instance of the application is already running.')
-        # focus the existing window
-        U32DLL.ShowWindow(hwnd, 5)
-        U32DLL.SetForegroundWindow(hwnd)
-        # bail
-        return True
-    return False
 
 # check if another instance of the application is already running.
 # if false, create a new instance of the application
 # if true, exit the current instance
-if not has_running_instance():
+if not window_has_running_instance(APP_NAME):
     root = tk.Tk()
     root.title(APP_NAME)
 else:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -44,7 +44,7 @@ import sys
 from UI.DebugWindow import DualOutput
 import traceback
 import sys
-from utils.utils import window_has_running_instance, bring_to_front
+from utils.utils import window_has_running_instance, bring_to_front, close_mutex
 
 dual = DualOutput()
 sys.stdout = dual
@@ -61,6 +61,9 @@ if not window_has_running_instance():
 else:
     bring_to_front(APP_NAME)
     sys.exit(0)
+
+# Register the close_mutex function to be called on exit
+atexit.register(close_mutex)
 
 # settings logic
 app_settings = SettingsWindow()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1304,7 +1304,6 @@ if app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]:
 
 root.bind("<<LoadSttModel>>", load_stt_model)
 
-p.terminate()
+root.mainloop()
 
-if __name__ == '__main__':
-    root.mainloop()  # run as usual
+p.terminate()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -55,7 +55,7 @@ APP_NAME = 'AI Medical Scribe'  # Application name
 # check if another instance of the application is already running.
 # if false, create a new instance of the application
 # if true, exit the current instance
-if not window_has_running_instance(APP_NAME):
+if not window_has_running_instance():
     root = tk.Tk()
     root.title(APP_NAME)
 else:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -52,7 +52,6 @@ sys.stderr = dual
 
 APP_NAME = 'AI Medical Scribe'  # Application name
 
-
 # check if another instance of the application is already running.
 # if false, create a new instance of the application
 # if true, exit the current instance

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -43,16 +43,43 @@ import ctypes
 import sys
 from UI.DebugWindow import DualOutput
 import traceback
+from ctypes import WinDLL
+import sys
 
 dual = DualOutput()
 sys.stdout = dual
 sys.stderr = dual
 
+APP_NAME = 'AI Medical Scribe'  # Application name
 
+# function to check if another instance of the application is already running
+def has_running_instance() -> bool:
+    """
+    Check if another instance of the application is already running.
+    Returns:
+        bool: True if another instance is running, False otherwise
+    """
+    U32DLL = WinDLL('user32')
+    # get the handle of any window matching 'APP_NAME'
+    hwnd = U32DLL.FindWindowW(None, APP_NAME)
+    print("Running instance check")
+    if hwnd:  # if a matching window exists...
+        print('Another instance of the application is already running.')
+        # focus the existing window
+        U32DLL.ShowWindow(hwnd, 5)
+        U32DLL.SetForegroundWindow(hwnd)
+        # bail
+        return True
+    return False
 
-# GUI Setup
-root = tk.Tk()
-root.title("AI Medical Scribe")
+# check if another instance of the application is already running.
+# if false, create a new instance of the application
+# if true, exit the current instance
+if not has_running_instance():
+    root = tk.Tk()
+    root.title(APP_NAME)
+else:
+    sys.exit(0)
 
 # settings logic
 app_settings = SettingsWindow()
@@ -1297,6 +1324,7 @@ if app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]:
 
 root.bind("<<LoadSttModel>>", load_stt_model)
 
-root.mainloop()
-
 p.terminate()
+
+if __name__ == '__main__':
+    root.mainloop()  # run as usual

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -17,7 +17,8 @@ def window_has_running_instance(app_name: str) -> bool:
     if hwnd:  # if a matching window exists...
         print('Another instance of the application is already running.')
         # focus the existing window
-        U32DLL.ShowWindow(hwnd, 5)
+        SW_SHOW = 5
+        U32DLL.ShowWindow(hwnd, SW_SHOW)
         U32DLL.SetForegroundWindow(hwnd)
         # bail
         return True

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -1,0 +1,24 @@
+
+from ctypes import WinDLL
+
+# function to check if another instance of the application is already running
+def window_has_running_instance(app_name: str) -> bool:
+    """
+    Check if another instance of the application is already running.
+    Parameters:
+        app_name (str): The name of the application
+    Returns:
+        bool: True if another instance is running, False otherwise
+    """
+    U32DLL = WinDLL('user32')
+    # get the handle of any window matching 'app_name'
+    hwnd = U32DLL.FindWindowW(None, app_name)
+    print("Running instance check")
+    if hwnd:  # if a matching window exists...
+        print('Another instance of the application is already running.')
+        # focus the existing window
+        U32DLL.ShowWindow(hwnd, 5)
+        U32DLL.SetForegroundWindow(hwnd)
+        # bail
+        return True
+    return False

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -1,17 +1,13 @@
 
-from ctypes import WinDLL
 import ctypes
 
 # function to check if another instance of the application is already running
-def window_has_running_instance(app_name: str) -> bool:
+def window_has_running_instance() -> bool:
     """
     Check if another instance of the application is already running.
-    Parameters:
-        app_name (str): The name of the application
     Returns:
         bool: True if another instance is running, False otherwise
     """
-    U32DLL = WinDLL('user32')
     # Define the mutex name
     MUTEX_NAME = 'Global\\FreeScribe_Instance'
     ERROR_ALREADY_EXISTS = 183
@@ -25,9 +21,9 @@ def bring_to_front(app_name: str):
     """
     Bring the window with the given handle to the front.
     Parameters:
-        hwnd: The handle of the window to bring to the front.
+        app_name (str): The name of the application window to bring to the front
     """
-    U32DLL = WinDLL('user32')
+    U32DLL = ctypes.WinDLL('user32')
     SW_SHOW = 5
     hwnd = U32DLL.FindWindowW(None, app_name)
     U32DLL.ShowWindow(hwnd, SW_SHOW)

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -23,6 +23,8 @@ def bring_to_front(app_name: str):
     Parameters:
         app_name (str): The name of the application window to bring to the front
     """
+
+    # TODO - Check platform and handle for different platform
     U32DLL = ctypes.WinDLL('user32')
     SW_SHOW = 5
     hwnd = U32DLL.FindWindowW(None, app_name)

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -1,6 +1,13 @@
 
 import ctypes
 
+# Define the mutex name and error code
+MUTEX_NAME = 'Global\\FreeScribe_Instance'
+ERROR_ALREADY_EXISTS = 183
+
+# Global variable to store the mutex handle
+mutex = None
+
 # function to check if another instance of the application is already running
 def window_has_running_instance() -> bool:
     """
@@ -8,9 +15,7 @@ def window_has_running_instance() -> bool:
     Returns:
         bool: True if another instance is running, False otherwise
     """
-    # Define the mutex name
-    MUTEX_NAME = 'Global\\FreeScribe_Instance'
-    ERROR_ALREADY_EXISTS = 183
+    global mutex
 
     # Create a named mutex
     mutex = ctypes.windll.kernel32.CreateMutexW(None, False, MUTEX_NAME)
@@ -29,3 +34,13 @@ def bring_to_front(app_name: str):
     hwnd = U32DLL.FindWindowW(None, app_name)
     U32DLL.ShowWindow(hwnd, SW_SHOW)
     U32DLL.SetForegroundWindow(hwnd)
+
+def close_mutex():
+    """
+    Close the mutex handle to release the resource.
+    """
+    global mutex
+    if mutex:
+        ctypes.windll.kernel32.ReleaseMutex(mutex)
+        ctypes.windll.kernel32.CloseHandle(mutex)
+        mutex = None

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -1,5 +1,6 @@
 
 from ctypes import WinDLL
+import ctypes
 
 # function to check if another instance of the application is already running
 def window_has_running_instance(app_name: str) -> bool:
@@ -11,15 +12,23 @@ def window_has_running_instance(app_name: str) -> bool:
         bool: True if another instance is running, False otherwise
     """
     U32DLL = WinDLL('user32')
-    # get the handle of any window matching 'app_name'
+    # Define the mutex name
+    MUTEX_NAME = 'Global\\FreeScribe_Instance'
+    ERROR_ALREADY_EXISTS = 183
+
+    # Create a named mutex
+    mutex = ctypes.windll.kernel32.CreateMutexW(None, False, MUTEX_NAME)
+    already_running = ctypes.windll.kernel32.GetLastError() == ERROR_ALREADY_EXISTS
+    return already_running
+
+def bring_to_front(app_name: str):
+    """
+    Bring the window with the given handle to the front.
+    Parameters:
+        hwnd: The handle of the window to bring to the front.
+    """
+    U32DLL = WinDLL('user32')
+    SW_SHOW = 5
     hwnd = U32DLL.FindWindowW(None, app_name)
-    print("Running instance check")
-    if hwnd:  # if a matching window exists...
-        print('Another instance of the application is already running.')
-        # focus the existing window
-        SW_SHOW = 5
-        U32DLL.ShowWindow(hwnd, SW_SHOW)
-        U32DLL.SetForegroundWindow(hwnd)
-        # bail
-        return True
-    return False
+    U32DLL.ShowWindow(hwnd, SW_SHOW)
+    U32DLL.SetForegroundWindow(hwnd)


### PR DESCRIPTION
### Issue
- #143 

### Changes
- Run only one instance of freescribe
- Only one instance of DebugWindow

## Summary by Sourcery

Restrict the FreeScribe application and DebugWindow to a single instance by implementing checks for existing instances and bringing them to the front if they are already running.

Enhancements:
- Ensure only one instance of the FreeScribe application can run at a time by checking for existing instances and bringing them to the front if found.
- Modify the DebugWindow to prevent multiple instances from opening and bring the existing window to the front if it is already open.