### PR TITLE
Fix: Prevent empty sections in settings window

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -167,7 +167,7 @@ class SettingsWindow():
 
 
         self.adv_general_settings = [
-            "Enable Scribe Template",
+            # "Enable Scribe Template", # Uncomment if you want to implement the feature right now removed as it doesn't have a real structured implementation
         ]
 
         self.editable_settings = {

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -467,8 +467,9 @@ class SettingsWindowUI:
         row = self._create_section_header("⚠️ Advanced Settings (For Advanced Users Only)", 0, text_colour="red")
         
         # General Settings
-        row = self._create_section_header("General Settings", row, text_colour="black")
-        row = create_settings_columns(self.settings.adv_general_settings, row)
+        if len(self.settings.adv_general_settings) > 0:
+            row = self._create_section_header("General Settings", row, text_colour="black")
+            row = create_settings_columns(self.settings.adv_general_settings, row)
 
         # Whisper Settings
         row = self._create_section_header("Whisper Settings", row, text_colour="black")


### PR DESCRIPTION
- removed scribe templates from settings and defaulted it to off, no real structure implemented around it

## Summary by Sourcery

Bug Fixes:
- Prevent empty sections from being displayed in the settings window by checking if the list length is greater than zero before rendering.