### PR TITLE
Clarify experimental Whisper settings

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -214,7 +214,7 @@ class SettingsWindow():
             "Whisper Model": "small.en",
             "Current Mic": "None",
             "Real Time": True,
-            "Real Time Audio Length": 5,
+            "Real Time Audio Length": 10,
             "Real Time Silence Length": 1,
             "Silence cut-off": 0.035,
             "LLM Container Name": "ollama",

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -36,10 +36,10 @@ class SettingsKeys(Enum):
     WHISPER_ENDPOINT = "Speech2Text (Whisper) Endpoint"
     WHISPER_SERVER_API_KEY = "Speech2Text (Whisper) API Key"
     WHISPER_ARCHITECTURE = "Speech2Text (Whisper) Architecture"
-    WHISPER_CPU_COUNT = "Speech2Text (Whisper) CPU Thread Count"
-    WHISPER_COMPUTE_TYPE = "Speech2Text (Whisper) Compute Type"
-    WHISPER_BEAM_SIZE = "Speech2Text (Whisper) Beam Size"
-    WHISPER_VAD_FILTER = "Use Speech2Text (Whisper) VAD Filter"
+    WHISPER_CPU_COUNT = "Whisper CPU Thread Count (Experimental)"
+    WHISPER_COMPUTE_TYPE = "Whisper Compute Type (Experimental)"
+    WHISPER_BEAM_SIZE = "Whisper Beam Size (Experimental)"
+    WHISPER_VAD_FILTER = "Use Whisper VAD Filter (Experimental)"
 
 
 class Architectures(Enum):


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Clarify that several Whisper settings are experimental.
- Change default real-time text to 10-second chunks

## Summary by Sourcery

Clarify experimental Whisper settings and increase the default real-time audio length to 10 seconds.

New Features:
- Increase the default real-time audio length to 10 seconds.

Enhancements:
- Mark several Whisper settings as experimental.