### PR TITLE
add .m4a support

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1022,7 +1022,7 @@ def generate_note_thread(text: str):
 
 def upload_file():
     global uploaded_file_path
-    file_path = filedialog.askopenfilename(filetypes=(("Audio files", "*.wav *.mp3"),))
+    file_path = filedialog.askopenfilename(filetypes=(("Audio files", "*.wav *.mp3 *.m4a"),))
     if file_path:
         uploaded_file_path = file_path
         threaded_send_audio_to_server()  # Add this line to process the file immediately


### PR DESCRIPTION
#246 The extension of the file generated by "Voice Memos" in iOS device is "*.m4a", the only change need to be made is the file chooser filter.

## Summary by Sourcery

New Features:
- Allow users to upload M4A files.