### PR TITLE
Send audio to Whisper endpoint from memory instead of temp file + other misc changes

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -162,7 +162,6 @@ class SettingsWindow():
             # "singleline",
             # "frmttriminc",
             # "frmtrmblln",
-            SettingsKeys.AUDIO_PROCESSING_TIMEOUT_LENGTH.value,
         ]
 
         self.adv_whisper_settings = [
@@ -177,6 +176,7 @@ class SettingsWindow():
 
         self.adv_general_settings = [
             # "Enable Scribe Template", # Uncomment if you want to implement the feature right now removed as it doesn't have a real structured implementation
+            SettingsKeys.AUDIO_PROCESSING_TIMEOUT_LENGTH.value,
         ]
 
         self.editable_settings = {

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -40,6 +40,7 @@ class SettingsKeys(Enum):
     WHISPER_COMPUTE_TYPE = "Speech2Text (Whisper) Compute Type"
     WHISPER_BEAM_SIZE = "Speech2Text (Whisper) Beam Size"
     WHISPER_VAD_FILTER = "Use Speech2Text (Whisper) VAD Filter"
+    AUDIO_PROCESSING_TIMEOUT_LENGTH = "Audio Processing Timeout (seconds)"
 
 
 class Architectures(Enum):
@@ -161,6 +162,7 @@ class SettingsWindow():
             # "singleline",
             # "frmttriminc",
             # "frmtrmblln",
+            SettingsKeys.AUDIO_PROCESSING_TIMEOUT_LENGTH.value,
         ]
 
         self.adv_whisper_settings = [
@@ -234,6 +236,7 @@ class SettingsWindow():
             "Pre-Processing": "Please break down the conversation into a list of facts. Take the conversation and transform it to a easy to read list:\n\n",
             "Post-Processing": "\n\nUsing the provided list of facts, review the SOAP note for accuracy. Verify that all details align with the information provided in the list of facts and ensure consistency throughout. Update or adjust the SOAP note as necessary to reflect the listed facts without offering opinions or subjective commentary. Ensure that the revised note excludes a \"Notes\" section and does not include a header for the SOAP note. Provide the revised note after making any necessary corrections.",
             "Show Scrub PHI": False,
+            SettingsKeys.AUDIO_PROCESSING_TIMEOUT_LENGTH.value: 180,
         }
 
         self.docker_settings = [

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -427,9 +427,14 @@ def toggle_recording():
 
             loading_window = LoadingWindow(root, "Processing Audio", "Processing Audio. Please wait.", on_cancel=lambda: (cancel_processing(), cancel_realtime_processing(REALTIME_TRANSCRIBE_THREAD_ID)))
 
+            try:
+                timeout_length = int(app_settings.editable_settings[SettingsKeys.AUDIO_PROCESSING_TIMEOUT_LENGTH.value])
+            except ValueError:
+                # default to 3minutes
+                timeout_length = 180
 
             timeout_timer = 0.0
-            while audio_queue.empty() is False and timeout_timer < app_settings.editable_settings[SettingsKeys.AUDIO_PROCESSING_TIMEOUT_LENGTH.value]:
+            while audio_queue.empty() is False and timeout_timer < timeout_length:
                 # break because cancel was requested
                 if is_audio_processing_realtime_canceled.is_set():
                     break
@@ -437,7 +442,7 @@ def toggle_recording():
                 timeout_timer += 0.1
                 timeout_timer = round(timeout_timer, 10)
                 if timeout_timer % 5 == 0:
-                    print(f"Waiting for audio processing to finish.Timeout after 60 seconds. Timer: {timeout_timer}s")
+                    print(f"Waiting for audio processing to finish. Timeout after {timeout_length} seconds. Timer: {timeout_timer}s")
                 time.sleep(0.1)
             
             loading_window.destroy()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -319,6 +319,7 @@ def realtime_text():
                             frames = []
                         else:
                             # Dont make the network request if frames is empty
+                            buffer.close()
                             continue
                         
                         buffer.seek(0)  # Reset buffer position to start

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -47,7 +47,7 @@ import sys
 from utils.utils import window_has_running_instance, bring_to_front, close_mutex
 import gc
 from pathlib import Path
-
+from decimal import Decimal
 from WhisperModel import TranscribeError
 
 
@@ -428,13 +428,16 @@ def toggle_recording():
             loading_window = LoadingWindow(root, "Processing Audio", "Processing Audio. Please wait.", on_cancel=lambda: (cancel_processing(), cancel_realtime_processing(REALTIME_TRANSCRIBE_THREAD_ID)))
 
 
-            timeout_timer = 0
-            while audio_queue.empty() is False and timeout_timer < 180:
+            timeout_timer = 0.0
+            while timeout_timer < 60.0:
                 # break because cancel was requested
                 if is_audio_processing_realtime_canceled.is_set():
                     break
                 
                 timeout_timer += 0.1
+                timeout_timer = round(timeout_timer, 10)
+                if timeout_timer % 5 == 0:
+                    print(f"Waiting for audio processing to finish.Timeout after 60 seconds. Timer: {timeout_timer}s")
                 time.sleep(0.1)
             
             loading_window.destroy()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -309,6 +309,7 @@ def realtime_text():
                     else:
                         print("Remote Real Time Whisper")
                         if frames:
+                            # Buffer to hold the audio data. This is used to send the audio data to the server.
                             buffer = io.BytesIO()
                             with wave.open(buffer, 'wb') as wf:
                                 wf.setnchannels(CHANNELS)
@@ -337,6 +338,7 @@ def realtime_text():
                         except Exception as e:
                             update_gui(f"Error: {e}")
                         finally:
+                            #close buffer. we dont need it anymore
                             buffer.close()
                 audio_queue.task_done()
     else:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -429,7 +429,7 @@ def toggle_recording():
 
 
             timeout_timer = 0.0
-            while timeout_timer < 60.0:
+            while audio_queue.empty() is False and timeout_timer < 60.0:
                 # break because cancel was requested
                 if is_audio_processing_realtime_canceled.is_set():
                     break

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -429,7 +429,7 @@ def toggle_recording():
 
 
             timeout_timer = 0.0
-            while audio_queue.empty() is False and timeout_timer < 60.0:
+            while audio_queue.empty() is False and timeout_timer < app_settings.editable_settings[SettingsKeys.AUDIO_PROCESSING_TIMEOUT_LENGTH.value]:
                 # break because cancel was requested
                 if is_audio_processing_realtime_canceled.is_set():
                     break

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -438,11 +438,16 @@ def toggle_recording():
                 # break because cancel was requested
                 if is_audio_processing_realtime_canceled.is_set():
                     break
-                
+                # increment timer
                 timeout_timer += 0.1
+                # round to 10 decimal places, account for floating point errors
                 timeout_timer = round(timeout_timer, 10)
+
+                # check if we should print a message every 5 seconds 
                 if timeout_timer % 5 == 0:
                     print(f"Waiting for audio processing to finish. Timeout after {timeout_length} seconds. Timer: {timeout_timer}s")
+                
+                # Wait for 100ms before checking again, to avoid busy waiting
                 time.sleep(0.1)
             
             loading_window.destroy()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -308,15 +308,18 @@ def realtime_text():
                             update_gui(result)
                     else:
                         print("Remote Real Time Whisper")
+                        buffer = io.BytesIO()
                         if frames:
                             # Buffer to hold the audio data. This is used to send the audio data to the server.
-                            buffer = io.BytesIO()
                             with wave.open(buffer, 'wb') as wf:
                                 wf.setnchannels(CHANNELS)
                                 wf.setsampwidth(p.get_sample_size(FORMAT))
                                 wf.setframerate(RATE)
                                 wf.writeframes(b''.join(frames))
                             frames = []
+                        else:
+                            # Dont make the network request if frames is empty
+                            continue
                         
                         buffer.seek(0)  # Reset buffer position to start
 


### PR DESCRIPTION
## Summary by Sourcery

Stream audio data to the Whisper endpoint directly instead of saving it to a temporary file first.

Enhancements:
- Improve performance of real-time transcription by streaming audio data directly to the Whisper endpoint instead of writing to a temporary file. This also fixes the bug.
- Added logging to timeout timer every 5 seconds updates debug window. 
- Made the timeout configurable via adv settings.

## Summary by Sourcery

Stream audio data to the Whisper endpoint directly from memory instead of saving it to a temporary file.  Add a configurable timeout for audio processing.

New Features:
- Make the audio processing timeout configurable in the advanced settings.

Enhancements:
- Log timeout status every 5 seconds.