### PR TITLE
Hotfix for the Dr. Hendy bug/Issues caused by merge conflict

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -355,8 +355,7 @@ def realtime_text():
 
                             print("Sending audio to server")
                             print("File informaton")
-                            print(f"File: {file_to_send}")
-                            print("File Size: ", os.path.getsize(file_to_send))
+                            print("File Size: ", len(buffer.getbuffer()), "bytes")
 
                             response = requests.post(app_settings.editable_settings[SettingsKeys.WHISPER_ENDPOINT.value], headers=headers,files=files, verify=verify)
                                 


### PR DESCRIPTION
Merge caused issues creating a bug that would not let the remote transcription work. It must be merged and a new tag build ASAP.

## Summary by Sourcery

Bug Fixes:
- Resolve issue where file size was incorrectly calculated, preventing successful transmission to the server.