### PR TITLE
Fix/stt model not loaded

### DIFF
--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -60,7 +60,7 @@ class LoadingWindow:
             self.popup = tk.Toplevel(parent)
             self.popup.title(title)
             # increased width for whisper model type
-            self.popup.geometry("240x105")  # Increased height for cancel button
+            self.popup.geometry("280x105")  # Increased height for cancel button
             self.popup.iconbitmap(get_file_path('assets','logo.ico'))
 
             if parent:

--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -59,7 +59,8 @@ class LoadingWindow:
             
             self.popup = tk.Toplevel(parent)
             self.popup.title(title)
-            self.popup.geometry("200x105")  # Increased height for cancel button
+            # increased width for whisper model type
+            self.popup.geometry("240x105")  # Increased height for cancel button
             self.popup.iconbitmap(get_file_path('assets','logo.ico'))
 
             if parent:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -182,7 +182,7 @@ def get_prompt(formatted_message):
 def threaded_toggle_recording():
     logging.debug(f"*** Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
     task_done_var = tk.BooleanVar(value=False)
-    stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
+    stt_loading_window = LoadingWindow(root, "Loading", "Loading models. Please wait.")
     stt_thread = threading.Thread(target=double_check_stt_model_loading, args=(task_done_var,))
     stt_thread.start()
     root.wait_variable(task_done_var)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -52,6 +52,10 @@ from UI.DebugWindow import DualOutput
 from utils.utils import window_has_running_instance, bring_to_front, close_mutex
 from WhisperModel import TranscribeError
 
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
 
 
 dual = DualOutput()
@@ -176,7 +180,8 @@ def get_prompt(formatted_message):
     }
 
 def threaded_toggle_recording():
-    print(f"*** Toggle Recording...\n {is_recording = } {stt_local_model = }")
+    logging.debug(f"Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
+
     # if using local whisper and model is not loaded, when starting recording
     if not is_recording and app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] and not stt_local_model:
         stt_loading_window = None

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -52,8 +52,13 @@ from UI.DebugWindow import DualOutput
 from utils.utils import window_has_running_instance, bring_to_front, close_mutex
 from WhisperModel import TranscribeError
 
+if os.environ.get("DEBUG"):
+    LOG_LEVEL = logging.DEBUG
+else:
+    LOG_LEVEL = logging.INFO
+
 logging.basicConfig(
-    level=logging.DEBUG,
+    level=LOG_LEVEL,
     format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
 )
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -59,7 +59,7 @@ else:
 
 logging.basicConfig(
     level=LOG_LEVEL,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
 )
 
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -182,16 +182,17 @@ def get_prompt(formatted_message):
 def threaded_toggle_recording():
     logging.debug(f"*** Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
     task_done_var = tk.BooleanVar(value=False)
+    stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
     stt_thread = threading.Thread(target=double_check_stt_model_loading, args=(task_done_var,))
     stt_thread.start()
     root.wait_variable(task_done_var)
+    stt_loading_window.destroy()
 
     thread = threading.Thread(target=toggle_recording)
     thread.start()
 
 
 def double_check_stt_model_loading(task_done_var):
-    stt_loading_window = None
     try:
         if is_recording:
             return
@@ -201,7 +202,7 @@ def double_check_stt_model_loading(task_done_var):
             return
         # if using local whisper and model is not loaded, when starting recording
         if stt_model_loading_thread_lock.locked():
-            stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
+
             timeout = 180
             time_start = time.monotonic()
             # wait until the other loading thread is done
@@ -213,8 +214,7 @@ def double_check_stt_model_loading(task_done_var):
                     messagebox.showerror("Error",
                                          f"Timed out while loading local STT model after {timeout} seconds.")
                     break
-            stt_loading_window.destroy()
-            stt_loading_window = None
+
         # double check
         if stt_local_model is None:
             # mandatory loading, synchronous
@@ -226,8 +226,6 @@ def double_check_stt_model_loading(task_done_var):
         messagebox.showerror("Error",
                              f"An error occurred while loading STT synchronously {type(e).__name__}: {e}")
     finally:
-        if stt_loading_window:
-            stt_loading_window.destroy()
         task_done_var.set(True)
 
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -180,8 +180,14 @@ def get_prompt(formatted_message):
     }
 
 def threaded_toggle_recording():
-    logging.debug(f"Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
+    logging.debug(f"*** Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
 
+    double_check_stt_model_loading()
+    thread = threading.Thread(target=toggle_recording)
+    thread.start()
+
+
+def double_check_stt_model_loading():
     # if using local whisper and model is not loaded, when starting recording
     if not is_recording and app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] and not stt_local_model:
         stt_loading_window = None
@@ -196,7 +202,8 @@ def threaded_toggle_recording():
                     if not stt_model_loading_thread_lock.locked():
                         break
                     if time.monotonic() - time_start > timeout:
-                        messagebox.showerror("Error", f"Timed out while loading local STT model after {timeout} seconds.")
+                        messagebox.showerror("Error",
+                                             f"Timed out while loading local STT model after {timeout} seconds.")
                         break
                 stt_loading_window.destroy()
                 stt_loading_window = None
@@ -211,8 +218,7 @@ def threaded_toggle_recording():
         finally:
             if stt_loading_window:
                 stt_loading_window.destroy()
-    thread = threading.Thread(target=toggle_recording)
-    thread.start()
+
 
 def threaded_realtime_text():
     thread = threading.Thread(target=realtime_text)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -187,7 +187,8 @@ def get_prompt(formatted_message):
 def threaded_toggle_recording():
     logging.debug(f"*** Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
     task_done_var = tk.BooleanVar(value=False)
-    stt_loading_window = LoadingWindow(root, "Loading", "Loading models. Please wait.")
+    model_name = app_settings.editable_settings["Whisper Model"].strip()
+    stt_loading_window = LoadingWindow(root, "Loading STT model", f"Loading {model_name} model. Please wait.")
     stt_thread = threading.Thread(target=double_check_stt_model_loading, args=(task_done_var,))
     stt_thread.start()
     root.wait_variable(task_done_var)
@@ -1417,7 +1418,7 @@ def _load_stt_model_thread():
     with stt_model_loading_thread_lock:
         global stt_local_model
         model = app_settings.editable_settings["Whisper Model"].strip()
-        stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
+        stt_loading_window = LoadingWindow(root, "Speech to Text", f"Loading Speech to Text {model} model. Please wait.")
         print(f"Loading STT model: {model}")
         try:
             unload_stt_model()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -226,6 +226,7 @@ def double_check_stt_model_loading(task_done_var, task_cancel_var):
                 if time.monotonic() - time_start > timeout:
                     messagebox.showerror("Error",
                                          f"Timed out while loading local STT model after {timeout} seconds.")
+                    task_cancel_var.set(True)
                     return
                 if not stt_model_loading_thread_lock.locked():
                     break

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -208,7 +208,7 @@ def double_check_stt_model_loading(task_done_var):
         # if using local whisper and model is not loaded, when starting recording
         if stt_model_loading_thread_lock.locked():
 
-            timeout = 180
+            timeout = 300
             time_start = time.monotonic()
             # wait until the other loading thread is done
             while True:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -52,7 +52,7 @@ from UI.DebugWindow import DualOutput
 from utils.utils import window_has_running_instance, bring_to_front, close_mutex
 from WhisperModel import TranscribeError
 
-if os.environ.get("DEBUG"):
+if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG
 else:
     LOG_LEVEL = logging.INFO

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1448,7 +1448,8 @@ def _load_stt_model_thread():
                 model,
                 device=device_type,
                 cpu_threads=int(app_settings.editable_settings[SettingsKeys.WHISPER_CPU_COUNT.value]),
-                compute_type=compute_type)
+                compute_type=compute_type
+            )
 
             print("STT model loaded successfully.")
         except Exception as e:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -13,6 +13,7 @@ and Research Students - Software Developer Alex Simko, Pemba Sherpa (F24), and N
 
 import ctypes
 import io
+import logging
 import sys
 import gc
 import os
@@ -143,6 +144,8 @@ GENERATION_THREAD_ID = None
 # Global instance of whisper model
 stt_local_model = None
 
+stt_model_loading_thread_lock = threading.Lock()
+
 
 def get_prompt(formatted_message):
 
@@ -173,6 +176,31 @@ def get_prompt(formatted_message):
     }
 
 def threaded_toggle_recording():
+    print(f"*** Toggle Recording...\n {is_recording = } {stt_local_model = }")
+    # if using local whisper and model is not loaded, when starting recording
+    if not is_recording and app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] and not stt_local_model:
+        try:
+            if stt_model_loading_thread_lock.locked():
+                stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
+                timeout = 180
+                time_start = time.monotonic()
+                # wait until the other loading thread is done
+                while True:
+                    time.sleep(0.1)
+                    if not stt_model_loading_thread_lock.locked():
+                        break
+                    if time.monotonic() - time_start > timeout:
+                        messagebox.showerror("Error", f"Timed out while loading local STT model after {timeout} seconds.")
+                        break
+                stt_loading_window.destroy()
+            # double check
+            if stt_local_model is None:
+                # mandatory loading, synchronous
+                t = load_stt_model()
+                t.join()
+        except Exception as e:
+            logging.exception(str(e))
+            messagebox.showerror("Error", f"An error occurred while loading STT synchronously {type(e).__name__}: {e}")
     thread = threading.Thread(target=toggle_recording)
     thread.start()
 
@@ -1336,8 +1364,9 @@ def load_stt_model(event=None):
     Args:
         event: Optional event parameter for binding to tkinter events.
     """
-    thread = threading.Thread(target=_load_stt_model_thread, daemon=True)
+    thread = threading.Thread(target=_load_stt_model_thread)
     thread.start()
+    return thread
 
 def _load_stt_model_thread():
     """
@@ -1350,35 +1379,36 @@ def _load_stt_model_thread():
         Exception: Any error that occurs during model loading is caught, logged,
                   and displayed to the user via a message box.
     """
-    global stt_local_model
-    model = app_settings.editable_settings["Whisper Model"].strip()
-    stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
-    print(f"Loading STT model: {model}")
-    try:
-        unload_stt_model()
-        device_type = get_selected_whisper_architecture()
-        set_cuda_paths()
+    with stt_model_loading_thread_lock:
+        global stt_local_model
+        model = app_settings.editable_settings["Whisper Model"].strip()
+        stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
+        print(f"Loading STT model: {model}")
+        try:
+            unload_stt_model()
+            device_type = get_selected_whisper_architecture()
+            set_cuda_paths()
 
-        compute_type = app_settings.editable_settings[SettingsKeys.WHISPER_COMPUTE_TYPE.value]
-        # Change the  compute type automatically if using a gpu one.
-        if device_type == Architectures.CPU.architecture_value and compute_type == "float16":
-            compute_type = "int8"
-            
+            compute_type = app_settings.editable_settings[SettingsKeys.WHISPER_COMPUTE_TYPE.value]
+            # Change the  compute type automatically if using a gpu one.
+            if device_type == Architectures.CPU.architecture_value and compute_type == "float16":
+                compute_type = "int8"
 
-        stt_local_model = WhisperModel(
-            model, 
-            device=device_type,
-            cpu_threads=int(app_settings.editable_settings[SettingsKeys.WHISPER_CPU_COUNT.value]),
-            compute_type=compute_type)
 
-        print("STT model loaded successfully.")
-    except Exception as e:
-        print(f"An error occurred while loading STT {type(e).__name__}: {e}")
-        stt_local_model = None
-        messagebox.showerror("Error", f"An error occurred while loading STT {type(e).__name__}: {e}")
-    finally:
-        stt_loading_window.destroy()
-        print("Closing STT loading window.")
+            stt_local_model = WhisperModel(
+                model,
+                device=device_type,
+                cpu_threads=int(app_settings.editable_settings[SettingsKeys.WHISPER_CPU_COUNT.value]),
+                compute_type=compute_type)
+
+            print("STT model loaded successfully.")
+        except Exception as e:
+            print(f"An error occurred while loading STT {type(e).__name__}: {e}")
+            stt_local_model = None
+            messagebox.showerror("Error", f"An error occurred while loading STT {type(e).__name__}: {e}")
+        finally:
+            stt_loading_window.destroy()
+            print("Closing STT loading window.")
 
 def unload_stt_model():
     """
@@ -1390,9 +1420,9 @@ def unload_stt_model():
     global stt_local_model
     if stt_local_model is not None:
         print("Unloading STT model from device.")
-        del stt_local_model
-        gc.collect()
+        # no risk of temporary "stt_local_model in globals() is False" with same gc effect
         stt_local_model = None
+        gc.collect()
         print("STT model unloaded successfully.")
     else:
         print("STT model is already unloaded.")

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -179,6 +179,7 @@ def threaded_toggle_recording():
     print(f"*** Toggle Recording...\n {is_recording = } {stt_local_model = }")
     # if using local whisper and model is not loaded, when starting recording
     if not is_recording and app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] and not stt_local_model:
+        stt_loading_window = None
         try:
             if stt_model_loading_thread_lock.locked():
                 stt_loading_window = LoadingWindow(root, "Speech to Text", "Loading Speech to Text. Please wait.")
@@ -193,6 +194,7 @@ def threaded_toggle_recording():
                         messagebox.showerror("Error", f"Timed out while loading local STT model after {timeout} seconds.")
                         break
                 stt_loading_window.destroy()
+                stt_loading_window = None
             # double check
             if stt_local_model is None:
                 # mandatory loading, synchronous
@@ -201,6 +203,9 @@ def threaded_toggle_recording():
         except Exception as e:
             logging.exception(str(e))
             messagebox.showerror("Error", f"An error occurred while loading STT synchronously {type(e).__name__}: {e}")
+        finally:
+            if stt_loading_window:
+                stt_loading_window.destroy()
     thread = threading.Thread(target=toggle_recording)
     thread.start()
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -211,7 +211,7 @@ def double_check_stt_model_loading(task_done_var, task_cancel_var):
         # if using local whisper and model is not loaded, when starting recording
         if stt_model_loading_thread_lock.locked():
             model_name = app_settings.editable_settings["Whisper Model"].strip()
-            stt_loading_window = LoadingWindow(root, "Loading STT model",
+            stt_loading_window = LoadingWindow(root, "Loading Voice to Text model",
                                                f"Loading {model_name} model. Please wait.",
                                                on_cancel=lambda: task_cancel_var.set(True))
             timeout = 300
@@ -225,7 +225,7 @@ def double_check_stt_model_loading(task_done_var, task_cancel_var):
                     return
                 if time.monotonic() - time_start > timeout:
                     messagebox.showerror("Error",
-                                         f"Timed out while loading local STT model after {timeout} seconds.")
+                                         f"Timed out while loading local Voice to Text model after {timeout} seconds.")
                     task_cancel_var.set(True)
                     return
                 if not stt_model_loading_thread_lock.locked():
@@ -241,7 +241,7 @@ def double_check_stt_model_loading(task_done_var, task_cancel_var):
     except Exception as e:
         logging.exception(str(e))
         messagebox.showerror("Error",
-                             f"An error occurred while loading STT synchronously {type(e).__name__}: {e}")
+                             f"An error occurred while loading Voice to Text model synchronously {type(e).__name__}: {e}")
     finally:
         if stt_loading_window:
             stt_loading_window.destroy()
@@ -1431,7 +1431,7 @@ def _load_stt_model_thread():
     with stt_model_loading_thread_lock:
         global stt_local_model
         model = app_settings.editable_settings["Whisper Model"].strip()
-        stt_loading_window = LoadingWindow(root, "Speech to Text", f"Loading Speech to Text {model} model. Please wait.")
+        stt_loading_window = LoadingWindow(root, "Voice to Text", f"Loading Voice to Text {model} model. Please wait.")
         print(f"Loading STT model: {model}")
         try:
             unload_stt_model()
@@ -1455,7 +1455,7 @@ def _load_stt_model_thread():
         except Exception as e:
             print(f"An error occurred while loading STT {type(e).__name__}: {e}")
             stt_local_model = None
-            messagebox.showerror("Error", f"An error occurred while loading STT {type(e).__name__}: {e}")
+            messagebox.showerror("Error", f"An error occurred while loading Voice to Text {type(e).__name__}: {e}")
         finally:
             stt_loading_window.destroy()
             print("Closing STT loading window.")


### PR DESCRIPTION
#276

## Summary by Sourcery

Load the Speech-to-Text model only once when starting a recording session.

Bug Fixes:
- Fixed an issue where the STT model was not loaded correctly, preventing transcription.

Enhancements:
- Improved the STT model loading process to prevent multiple loading attempts.