### PR TITLE
Setting UI finetune and Version display

### DIFF
--- a/src/FreeScribe.client/UI/MarkdownWindow.py
+++ b/src/FreeScribe.client/UI/MarkdownWindow.py
@@ -3,6 +3,7 @@ import markdown as md
 import tkinter as tk
 from tkhtmlview import HTMLLabel
 from utils.file_utils import get_file_path
+from utils.utils import get_application_version
 
 class MarkdownWindow:
     """
@@ -37,8 +38,13 @@ class MarkdownWindow:
         self.window.iconbitmap(get_file_path('assets', 'logo.ico'))
 
         # Footer frame to hold checkbox and close button
-        footer_frame = tk.Frame(self.window)
+        footer_frame = tk.Frame(self.window,bg="lightgray")
         footer_frame.pack(side=tk.BOTTOM, fill="x", padx=10, pady=10)
+
+        # Add a version label to the footer
+        version = get_application_version()
+        version_label = tk.Label(footer_frame, text=f"FreeScribe Client {version}",bg="lightgray",fg="black").pack(side="left", expand=True, padx=2, pady=5)
+
 
         # Create a frame to hold the HTMLLabel and scrollbar
         frame = tk.Frame(self.window)
@@ -63,13 +69,13 @@ class MarkdownWindow:
             ).pack(side=tk.BOTTOM, padx=5)
 
             close_button = tk.Button(
-                footer_frame, text="Close", command=lambda: self._on_close(var, callback)
+                footer_frame, text="Close", command=lambda: self._on_close(var, callback),font=("Arial", 12),width=6,height=1
             )
         else:
-            close_button = tk.Button(footer_frame, text="Close", command=self.window.destroy)
+            close_button = tk.Button(footer_frame, text="Close", command=self.window.destroy,font=("Arial", 12),width=6,height=1)
 
         # Add the close button
-        close_button.pack(side=tk.BOTTOM, padx=5)
+        close_button.pack(side=tk.BOTTOM, padx=5, pady=5)
 
         # Adjust window size based on content with constraints
         self._adjust_window_size(html_label, scrollbar)

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -630,13 +630,3 @@ class SettingsWindow():
                 old_cpu_count != self.editable_settings_entries[SettingsKeys.WHISPER_CPU_COUNT.value].get() or
                 old_compute_type != self.editable_settings_entries[SettingsKeys.WHISPER_COMPUTE_TYPE.value].get()):
             self.main_window.root.event_generate("<<LoadSttModel>>")
-
-    def get_application_version(self):
-        version_str = "vx.x.x.alpha"
-        try:
-            with open(get_file_path('__version__'), 'r') as file:
-                version_str = file.read().strip()
-        except Exception as e:
-            print(f"Error loading version file ({type(e).__name__}). {e}")
-        finally:
-            return version_str

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -26,6 +26,7 @@ from UI.Widgets.AudioMeter import AudioMeter
 import threading
 from Model import Model, ModelManager
 from utils.file_utils import get_file_path
+from utils.utils import get_application_version
 from UI.MarkdownWindow import MarkdownWindow
 from UI.Widgets.MicrophoneSelector import MicrophoneSelector
 from UI.SettingsWindow import SettingsKeys, FeatureToggle, Architectures, SettingsWindow
@@ -102,8 +103,8 @@ class SettingsWindowUI:
         self.docker_settings_frame = ttk.Frame(self.notebook)
 
         self.notebook.add(self.general_settings_frame, text="General Settings")
-        self.notebook.add(self.llm_settings_frame, text="AI Settings")
         self.notebook.add(self.whisper_settings_frame, text="Speech-to-Text Settings")
+        self.notebook.add(self.llm_settings_frame, text="AI Settings")
         self.notebook.add(self.advanced_frame, text="Advanced Settings")
 
         self.settings_window.protocol("WM_DELETE_WINDOW", self.close_window)
@@ -559,15 +560,15 @@ class SettingsWindowUI:
         This method creates and places buttons for saving settings, resetting to default,
         and closing the settings window.
         """
-        footer_frame = tk.Frame(self.main_frame)
+        footer_frame = tk.Frame(self.main_frame,bg="lightgray", height=30)
         footer_frame.pack(side="bottom", fill="x")
 
         # Place the "Help" button on the left
         tk.Button(footer_frame, text="Help", width=10, command=self.create_help_window).pack(side="left", padx=2, pady=5)
 
         # Place the label in the center
-        version = self.settings.get_application_version()
-        tk.Label(footer_frame, text=f"FreeScribe Client {version}").pack(side="left", expand=True, padx=2, pady=5)
+        version = get_application_version()
+        tk.Label(footer_frame, text=f"FreeScribe Client {version}",bg="lightgray",fg="black").pack(side="left", expand=True, padx=2, pady=5)
 
         # Create a frame for the right-side elements
         right_frame = tk.Frame(footer_frame)
@@ -668,12 +669,29 @@ class SettingsWindowUI:
         
         # Add a note at the bottom of the general settings frame
         note_text = (
-            "Note: 'Show Scrub PHI' will only work for local LLM and private network.\n"
-            "For internet-facing endpoint, it will be enabled regardless of the 'Show Scrub PHI' value."
-        )
-        note_label = tk.Label(self.general_settings_frame, text=note_text, fg="red", wraplength=400, justify="left")
-        note_label.grid(padx=10, pady=5, sticky="w")
+        "NOTE: To protect personal health information (PHI), we recommend using a local network.\n"
+        "The 'Show Scrub PHI' feature is only applicable for local LLMs and private networks.\n"
+        "For internet-facing endpoints, this feature will always be enabled, regardless of the 'Show Scrub PHI' setting."
+    )
 
+        # Create a frame to hold the note labels
+        note_frame = tk.Frame(self.general_settings_frame)
+        note_frame.grid(padx=10, pady=5, sticky="w")
+
+        # Add the red * label
+        star_label = tk.Label(note_frame, text="*", fg="red", font=("Arial", 10, "bold"))
+        star_label.grid(row=0, column=0, sticky="w")
+
+        # Add the rest of the text in black (bold and underlined)
+        note_label = tk.Label(
+            note_frame,
+            text=note_text,
+            fg="black",  # Set text color to black
+            font=("Arial", 8, "bold underline"),  # Set font to bold and underlined
+            wraplength=400,
+            justify="left"
+        )
+        note_label.grid(row=0, column=1, sticky="w")
 
     def _create_checkbox(self, frame, label, setting_name, row_idx, setting_key=None):
         """

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -48,6 +48,7 @@ from Model import  ModelManager
 from utils.ip_utils import is_private_ip
 from utils.file_utils import get_file_path, get_resource_path
 from utils.OneInstance import OneInstance
+from utils.utils import get_application_version
 from UI.DebugWindow import DualOutput
 from utils.utils import window_has_running_instance, bring_to_front, close_mutex
 from WhisperModel import TranscribeError
@@ -1259,6 +1260,7 @@ def set_full_view():
     pause_button.grid(row=1, column=2, pady=5, padx=0,sticky='nsew')
     switch_view_button.grid(row=1, column=7, pady=5, padx=0,sticky='nsew')
     blinking_circle_canvas.grid(row=1, column=8, padx=0,pady=5)
+    footer_frame.grid()
 
     window.toggle_menu_bar(enable=True)
 
@@ -1320,7 +1322,7 @@ def set_minimal_view():
     response_display.grid_remove()
     timestamp_listbox.grid_remove()
     blinking_circle_canvas.grid_remove()
-
+    footer_frame.grid_remove()
     # Configure minimal view button sizes and placements
     mic_button.config(width=2, height=1)
     pause_button.config(width=2, height=1)
@@ -1632,6 +1634,14 @@ timestamp_listbox.grid(row=0, column=9, columnspan=2, rowspan=3, padx=5, pady=15
 timestamp_listbox.bind('<<ListboxSelect>>', show_response)
 timestamp_listbox.insert(tk.END, "Temporary Note History")
 timestamp_listbox.config(fg='grey')
+
+# Add a footer frame at the bottom of the window
+footer_frame = tk.Frame(root, bg="lightgray", height=30)
+footer_frame.grid(row=100, column=0, columnspan=100, sticky="ew")  # Use grid instead of pack
+
+# Add "Version 2" label in the center of the footer
+version = get_application_version()
+version_label = tk.Label(footer_frame, text=f"FreeScribe Client {version}",bg="lightgray",fg="black").pack(side="left", expand=True, padx=2, pady=5)
 
 window.update_aiscribe_texts(None)
 # Bind Alt+P to send_and_receive function

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -1,6 +1,6 @@
 
 import ctypes
-
+from utils.file_utils import get_file_path
 # Define the mutex name and error code
 MUTEX_NAME = 'Global\\FreeScribe_Instance'
 ERROR_ALREADY_EXISTS = 183
@@ -44,3 +44,13 @@ def close_mutex():
         ctypes.windll.kernel32.ReleaseMutex(mutex)
         ctypes.windll.kernel32.CloseHandle(mutex)
         mutex = None
+
+def get_application_version():
+        version_str = "vx.x.x.alpha"
+        try:
+            with open(get_file_path('__version__'), 'r') as file:
+                version_str = file.read().strip()
+        except Exception as e:
+            print(f"Error loading version file ({type(e).__name__}). {e}")
+        finally:
+            return version_str


### PR DESCRIPTION
Reordered Setting page tabs
UI and wording modified in Setting page for Show Scrub PHI
Version display in footer added in Main screen and Help screen
![image](https://github.com/user-attachments/assets/3c42bfd0-6a78-479f-a209-45599b1c617f)

## Summary by Sourcery

Update the settings UI and add version display.

New Features:
- Display the application version in the footer of the main screen and help screen.

Tests:
- Updated snapshot tests for the main window and help window.