### PR TITLE
UI finetuning

### DIFF
--- a/src/FreeScribe.client/UI/MarkdownWindow.py
+++ b/src/FreeScribe.client/UI/MarkdownWindow.py
@@ -39,12 +39,10 @@ class MarkdownWindow:
 
         # Footer frame to hold checkbox and close button
         footer_frame = tk.Frame(self.window,bg="lightgray")
-        footer_frame.pack(side=tk.BOTTOM, fill="x", padx=10, pady=10)
-
+        footer_frame.pack(side=tk.BOTTOM, fill="x")
         # Add a version label to the footer
         version = get_application_version()
-        version_label = tk.Label(footer_frame, text=f"FreeScribe Client {version}",bg="lightgray",fg="black").pack(side="left", expand=True, padx=2, pady=5)
-
+        
 
         # Create a frame to hold the HTMLLabel and scrollbar
         frame = tk.Frame(self.window)
@@ -64,18 +62,26 @@ class MarkdownWindow:
         # Optional checkbox and callback handling
         if callback:
             var = tk.BooleanVar()
-            tk.Checkbutton(
-                footer_frame, text="Don't show this message again", variable=var
-            ).pack(side=tk.BOTTOM, padx=5)
-
-            close_button = tk.Button(
-                footer_frame, text="Close", command=lambda: self._on_close(var, callback),font=("Arial", 12),width=6,height=1
-            )
+            # Center the checkbox
+            check_button = tk.Checkbutton(footer_frame, text="Don't show this message again", variable=var, bg="lightgray").grid(row=0, column=1, padx=5, pady=3)
+            # Center the close button
+            close_button = tk.Button(footer_frame, text="Close", command=lambda: self._on_close(var, callback), width=6).grid(row=1, column=1, padx=5, pady=3)
+            # version_label with sunken relief, smaller and right-aligned within footer_frame
+            version_label = tk.Label(footer_frame, text=f"Version: {get_application_version()}", pady=2, padx=5, relief="sunken", font=("Arial", 8)).grid(row=1, column=2, sticky='se')
+            # Adjust column weights to center elements
+            footer_frame.grid_columnconfigure(0, weight=1)
+            footer_frame.grid_columnconfigure(1, weight=1)
+            footer_frame.grid_columnconfigure(2, weight=0)
         else:
-            close_button = tk.Button(footer_frame, text="Close", command=self.window.destroy,font=("Arial", 12),width=6,height=1)
-
-        # Add the close button
-        close_button.pack(side=tk.BOTTOM, padx=5, pady=5)
+            # Center the close button
+            close_button = tk.Button(footer_frame, text="Close", command=self.window.destroy, width=6).grid(row=0, column=1, columnspan=2, padx=5, pady=3)
+            # Place the version label in the bottom right corner
+            version_label = tk.Label(footer_frame, text=f"Version: {get_application_version()}", pady=2, padx=5, relief="sunken", font=("Arial", 8)).grid(row=0, column=3, sticky='e')
+            # Adjust column weights to center the close button and anchor the version label to the right
+            footer_frame.grid_columnconfigure(0, weight=1)
+            footer_frame.grid_columnconfigure(1, weight=1)
+            footer_frame.grid_columnconfigure(2, weight=1)
+            footer_frame.grid_columnconfigure(3, weight=0)  
 
         # Adjust window size based on content with constraints
         self._adjust_window_size(html_label, scrollbar)

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -24,6 +24,7 @@ from tkinter import ttk, messagebox
 import requests
 import numpy as np
 from utils.file_utils import get_resource_path, get_file_path
+from utils.utils import get_application_version
 from Model import ModelManager
 import threading
 from UI.Widgets.MicrophoneSelector import MicrophoneState
@@ -352,7 +353,7 @@ class SettingsWindow():
             "openai_api_key": self.OPENAI_API_KEY,
             "editable_settings": self.editable_settings,
             # "api_style": self.API_STYLE # FUTURE FEATURE REVISION
-            "app_version": self.get_application_version()
+            "app_version": get_application_version()
         }
         with open(get_resource_path('settings.txt'), 'w') as file:
             json.dump(settings, file)

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -511,7 +511,7 @@ class SettingsWindowUI:
         
         # Prompting Settings
         row = self._create_section_header("Prompting Settings", row, text_colour="black")
-        self.aiscribe_text, row = self._create_text_area("Pre Prompting", self.settings.AISCRIBE, row)
+        self.aiscribe_text, row = self._create_text_area("Note Generation Prompt", self.settings.AISCRIBE, row)
         self.aiscribe2_text, row = self._create_text_area("Post Prompting", self.settings.AISCRIBE2, row)
         
         # Processing Sections
@@ -571,7 +571,7 @@ class SettingsWindowUI:
         tk.Label(footer_frame, text=f"FreeScribe Client {version}",bg="lightgray",fg="black").pack(side="left", expand=True, padx=2, pady=5)
 
         # Create a frame for the right-side elements
-        right_frame = tk.Frame(footer_frame)
+        right_frame = tk.Frame(footer_frame,bg="lightgray")
         right_frame.pack(side="right")
 
         # Pack all other buttons into the right frame
@@ -726,7 +726,7 @@ class SettingsWindowUI:
         """
         tk.Label(frame, text=label).grid(row=row_idx, column=0, padx=0, pady=5, sticky="w")
         value = self.settings.editable_settings[setting_name]
-        entry = tk.Entry(frame, width=25)
+        entry = tk.Entry(frame, width=17)
         entry.insert(0, str(value))
         entry.grid(row=row_idx, column=1, padx=0, pady=5, sticky="w")
         self.settings.editable_settings_entries[setting_name] = entry


### PR DESCRIPTION
Fix : Version footer finetuned in intro and Help page
Word change "Pre Prompting" box to "Note Generation Prompt"
Reduced input box size in AI settings in advanced setting

## Summary by Sourcery

Update the UI elements for the version footer, prompting text, and input box size.

Enhancements:
- Standardize the version footer in the introduction and help pages.
- Change the label of the pre-prompting input box to "Note Generation Prompt".
- Reduce the size of the input box in the AI settings advanced settings.