### PR TITLE
ci(release-action): Added the v*.*.*-RC* tag ability.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "v*.*.*"
       - "v*.*.*.alpha"
+      - "v*.*.*-RC*"
 
 jobs:
   build-windows:


### PR DESCRIPTION
This was added for release candidates. Allow us to auto-build release candidates.

## Summary by Sourcery

CI:
- Trigger the release workflow when a `v*.*.*-RC*` tag is pushed.