### PR TITLE
keep item selected in timestamp listbox after losing focus

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1712,7 +1712,7 @@ history_frame.grid_rowconfigure(0, weight=4)  # Timestamp takes more space
 history_frame.grid_rowconfigure(1, weight=1)  # Mic test takes less space
 
 # Add the timestamp listbox
-timestamp_listbox = tk.Listbox(history_frame, height=30)
+timestamp_listbox = tk.Listbox(history_frame, height=30, exportselection=False)
 timestamp_listbox.grid(row=0, column=0, rowspan=3,sticky='nsew')
 timestamp_listbox.bind('<<ListboxSelect>>', show_response)
 timestamp_listbox.insert(tk.END, "Temporary Note History")


### PR DESCRIPTION
#321 
By default, exportselection=True causes the selection to be cleared when focus is lost. Setting it to False preserves the selection, maintaining the blue highlight color even after focus is lost.

## Summary by Sourcery

Enhancements:
- Set `exportselection=False` on the timestamp listbox to prevent the selection from being cleared when focus is lost.