### PR TITLE
URGENT: fix(post-pre-process): Fixed trying to access text boxes when feature is disabled in FeatureToggle.

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -610,8 +610,11 @@ class SettingsWindowUI:
 
         self.settings.update_whisper_model()
 
-        self.settings.editable_settings["Pre-Processing"] = self.preprocess_text.get("1.0", "end-1c") # end-1c removes the trailing newline
-        self.settings.editable_settings["Post-Processing"] = self.postprocess_text.get("1.0", "end-1c") # end-1c removes the trailing newline
+        if FeatureToggle.PRE_PROCESSING is True:
+            self.settings.editable_settings["Pre-Processing"] = self.preprocess_text.get("1.0", "end-1c") # end-1c removes the trailing newline
+        
+        if FeatureToggle.POST_PROCESSING is True:
+            self.settings.editable_settings["Post-Processing"] = self.postprocess_text.get("1.0", "end-1c") # end-1c removes the trailing newline
 
         # save architecture
         self.settings.editable_settings[SettingsKeys.LLM_ARCHITECTURE.value] = self.architecture_dropdown.get()


### PR DESCRIPTION
This bug only occurred on save settings as it would try to pull the text box data from non-existent data field

## Summary by Sourcery

Bug Fixes:
- Prevent attempts to read pre-processing and post-processing text box data when the corresponding features are disabled.