### PR TITLE
fix: Disable Microphone Select option while Recording

### DIFF
--- a/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
+++ b/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
@@ -48,6 +48,7 @@ class MicrophoneTestFrame:
 
         # Initialize the selected microphone
         self.initialize_selected_microphone()
+        self._frame_original_styles = {}
 
     def initialize_microphones(self):
         """
@@ -309,10 +310,19 @@ class MicrophoneTestFrame:
         self.mic_dropdown.state(['!disabled' if enabled else 'disabled']) 
         self.status_label.state(['!disabled' if enabled else 'disabled']) 
         for segment in self.segments: 
-            if isinstance(segment, (ttk.Frame, tk.Frame)): 
-                # ttk.Frame and tk.Frame do not support the 'state' option 
-                continue 
-            segment.state(['!disabled' if enabled else 'disabled'])  
+            if isinstance(segment, (ttk.Frame, tk.Frame)):
+                if enabled:
+                    # Restore original style if it exists
+                    original_style = self._frame_original_styles.get(segment, '')
+                    segment.configure(style=original_style)
+                else:
+                    # Store original style and apply disabled style
+                    current_style = segment.cget('style')
+                    if segment not in self._frame_original_styles:
+                        self._frame_original_styles[segment] = current_style
+                    segment.configure(style='Disabled.TFrame')
+            else:
+                segment.state(['!disabled' if enabled else 'disabled'])  
 
     def __del__(self):
         """

--- a/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
+++ b/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
@@ -97,6 +97,7 @@ class MicrophoneTestFrame:
 
         # Create styles for all elements
         style = ttk.Style()
+        style.configure('Disabled.TFrame', background='lightgray')  # Gray background for disabled state 
         style.configure('Mic.TCombobox', padding=(5, 5, 5, 5))
         style.configure('Green.TFrame', background='#2ecc71')
         style.configure('Yellow.TFrame', background='#f1c40f')
@@ -303,6 +304,15 @@ class MicrophoneTestFrame:
         Get the selected microphone index.
         """
         return MicrophoneState.SELECTED_MICROPHONE_INDEX
+
+    def set_mic_test_state(self, enabled):         
+        self.mic_dropdown.state(['!disabled' if enabled else 'disabled']) 
+        self.status_label.state(['!disabled' if enabled else 'disabled']) 
+        for segment in self.segments: 
+            if isinstance(segment, (ttk.Frame, tk.Frame)): 
+                # ttk.Frame and tk.Frame do not support the 'state' option 
+                continue 
+            segment.state(['!disabled' if enabled else 'disabled'])  
 
     def __del__(self):
         """

--- a/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
+++ b/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
@@ -306,9 +306,29 @@ class MicrophoneTestFrame:
         """
         return MicrophoneState.SELECTED_MICROPHONE_INDEX
 
-    def set_mic_test_state(self, enabled):         
-        self.mic_dropdown.state(['!disabled' if enabled else 'disabled']) 
-        self.status_label.state(['!disabled' if enabled else 'disabled']) 
+    def set_mic_test_state(self, enabled):
+        """
+        Enable or disable the microphone test state for the UI components.
+
+        This method updates the state of the microphone dropdown, status label, and segments 
+        based on the `enabled` parameter. If `enabled` is True, the components are set to an 
+        enabled state. If `enabled` is False, the components are disabled. For frame segments, 
+        the style is also updated to reflect the disabled state.
+
+        Args:
+            enabled (bool): If True, enable the microphone test state. If False, disable it.
+
+        Notes:
+            - For `ttk.Frame` or `tk.Frame` segments, the original style is stored before applying 
+            the disabled style. This allows the original style to be restored when re-enabled.
+            - The `_frame_original_styles` dictionary is used to store the original styles of frames.
+
+        Example:
+            >>> self.set_mic_test_state(True)  # Enable microphone test state
+            >>> self.set_mic_test_state(False) # Disable microphone test state
+        """
+        self.mic_dropdown.state(['!disabled' if enabled else 'disabled'])
+        self.status_label.state(['!disabled' if enabled else 'disabled'])         
         for segment in self.segments: 
             if isinstance(segment, (ttk.Frame, tk.Frame)):
                 if enabled:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -656,6 +656,7 @@ def disable_recording_ui_elements():
     response_display.scrolled_text.configure(state='disabled')
     timestamp_listbox.config(state='disabled')
     clear_button.config(state='disabled')
+    mic_test.set_mic_test_state(False)
 
 def enable_recording_ui_elements():
     window.enable_settings_menu()
@@ -665,6 +666,7 @@ def enable_recording_ui_elements():
     upload_button.config(state='normal')
     timestamp_listbox.config(state='normal')
     clear_button.config(state='normal')
+    mic_test.set_mic_test_state(True)
     
 
 def cancel_processing():


### PR DESCRIPTION
Created a function `set_mic_test_state` to disable microphone select while recording is on

## Summary by Sourcery

Bug Fixes:
- Prevent issues caused by changing microphone input while recording.