### PR TITLE
fix: remove duplication of constants

### DIFF
--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -23,6 +23,8 @@ class SettingsKeys(Enum):
     LOCAL_LLM_MODEL = "AI Model"
     LLM_ENDPOINT = "AI Server Endpoint"
     LLM_SERVER_API_KEY = "AI Server API Key"
+    Enable_Word_Count_Validation = "Enable Word Count Validation"
+    Enable_AI_Conversation_Validation = "Enable AI Conversation Validation"
 
 
 class Architectures(Enum):

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -31,47 +31,6 @@ from utils.ip_utils import is_valid_url
 import multiprocessing
 
 
-class SettingsKeys(Enum):
-    LOCAL_WHISPER = "Built-in Speech2Text"
-    WHISPER_ENDPOINT = "Speech2Text (Whisper) Endpoint"
-    WHISPER_SERVER_API_KEY = "Speech2Text (Whisper) API Key"
-    WHISPER_ARCHITECTURE = "Speech2Text (Whisper) Architecture"
-    WHISPER_CPU_COUNT = "Whisper CPU Thread Count (Experimental)"
-    WHISPER_COMPUTE_TYPE = "Whisper Compute Type (Experimental)"
-    WHISPER_BEAM_SIZE = "Whisper Beam Size (Experimental)"
-    WHISPER_VAD_FILTER = "Use Whisper VAD Filter (Experimental)"
-    AUDIO_PROCESSING_TIMEOUT_LENGTH = "Audio Processing Timeout (seconds)"
-    SILERO_SPEECH_THRESHOLD = "Silero Speech Threshold"
-    USE_TRANSLATE_TASK = "Translate Speech to English Text"
-    WHISPER_LANGUAGE_CODE = "Whisper Language Code"
-    S2T_SELF_SIGNED_CERT = "S2T Server Self-Signed Certificates"
-    LLM_ARCHITECTURE = "Architecture"
-    USE_PRESCREEN_AI_INPUT = "Use Pre-Screen AI Input"
-    Enable_Word_Count_Validation = "Enable Word Count Validation"
-    Enable_AI_Conversation_Validation = "Enable AI Conversation Validation"
-
-
-class Architectures(Enum):
-    CPU = ("CPU", "cpu")
-    CUDA = ("CUDA (Nvidia GPU)", "cuda")
-
-    @property
-    def label(self):
-        return self._value_[0]
-
-    @property
-    def architecture_value(self):
-        return self._value_[1]
-
-
-
-class FeatureToggle:
-    DOCKER_SETTINGS_TAB = False
-    DOCKER_STATUS_BAR = False
-    POST_PROCESSING = False
-    PRE_PROCESSING = False
-
-
 class SettingsWindow():
     """
     Manages application settings related to audio processing and external API services.


### PR DESCRIPTION
To avoid circular importing, constants in `SettingsWindow` are extracted to a new file `SettingsConstant`.
Different choices must have been made in some merge requests; now there are two copies, one in SettingsWindow, and the other in the new place.
This PR is to fix it by removing duplicated constants in the original place.
Its change is appended to the new place.

## Summary by Sourcery

Chores:
- Remove duplicate constants.

## Summary by Sourcery

Chores:
- Remove duplicated constants from `SettingsWindow.py` after they were moved to `SettingsConstant.py` to resolve circular import issues.