### PR TITLE
fix: improve microphone test frame functionality

### DIFF
--- a/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
+++ b/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
@@ -206,16 +206,14 @@ class MicrophoneTestFrame:
             self.mic_dropdown.set(current_selected_name)
             # Reopen the stream with the current selected microphone
             self.reopen_stream()
-        else:
+        elif self.mic_list:
             # If the selected microphone is no longer available, select the first one
-            if self.mic_list:
-                self.update_selected_microphone(self.mic_list[0][0])
-                self.mic_dropdown.set(self.mic_list[0][1])
-            else:
-                self.status_label.config(text="Error: No microphones available", foreground="red")
-                MicrophoneState.SELECTED_MICROPHONE_INDEX = None
-                MicrophoneState.SELECTED_MICROPHONE_NAME = None
-
+            self.update_selected_microphone(self.mic_list[0][0])
+            self.mic_dropdown.set(self.mic_list[0][1])
+        else:
+            self.status_label.config(text="Error: No microphones available", foreground="red")
+            MicrophoneState.SELECTED_MICROPHONE_INDEX = None
+            MicrophoneState.SELECTED_MICROPHONE_NAME = None
     def update_selected_microphone(self, selected_index):
         """
         Update the selected microphone index and name.


### PR DESCRIPTION
- Check dropdown state before click action to prevent unnecessary reinitialization
- Make the volume meter more sensitive to low volumes by adjusting the scaling factor
- Adjust thresholds for volume levels to better represent audio input
- Ensure the stream resumes with the previously selected microphone if no new selection is made

Files changed:
- MicrophoneTestFrame.py

## Summary by Sourcery

Improve the microphone test frame functionality by preventing unnecessary re-initializations when clicking the dropdown, adjusting the volume meter sensitivity for low volumes, and ensuring the stream resumes with the previously selected microphone.

Bug Fixes:
- Prevent re-initialization of audio when clicking the dropdown if it is already disabled.
- Fix issue where the selected microphone was reset if it was still available after re-initializing audio.

Enhancements:
- Adjust the volume meter scaling to better represent low volume levels.
- Refine the thresholds for volume level colors in the volume meter.