### PR TITLE
fix: Help window scroll fix

### DIFF
--- a/src/FreeScribe.client/UI/MarkdownWindow.py
+++ b/src/FreeScribe.client/UI/MarkdownWindow.py
@@ -38,28 +38,26 @@ class MarkdownWindow:
         self.window.iconbitmap(get_file_path('assets', 'logo.ico'))
 
         # Footer frame to hold checkbox and close button
-        footer_frame = tk.Frame(self.window, bg="lightgray")
+        footer_frame = tk.Frame(self.window,bg="lightgray")
         footer_frame.pack(side=tk.BOTTOM, fill="x")
         # Add a version label to the footer
         version = get_application_version()
+        
 
         # Create a frame to hold the HTMLLabel and scrollbar
         frame = tk.Frame(self.window)
         frame.pack(fill="both", expand=True, padx=10, pady=10)
 
         # Create the HTMLLabel widget
-        self.html_label = HTMLLabel(frame, html=content)
-        self.html_label.pack(side="left", fill="both", expand=True)
+        html_label = HTMLLabel(frame, html=content)
+        html_label.pack(side="left", fill="both", expand=True)
 
         # Create the scrollbar
-        self.scrollbar = tk.Scrollbar(frame, orient="vertical", command=self.html_label.yview)
-        self.scrollbar.pack(side="right", fill="y")
+        scrollbar = tk.Scrollbar(frame, orient="vertical", command=html_label.yview)
+        scrollbar.pack(side="right", fill="y")
 
         # Configure the HTMLLabel to use the scrollbar
-        self.html_label.config(yscrollcommand=self.scrollbar.set)
-
-        # Bind mouse wheel event to the HTML label
-        self.html_label.bind("<MouseWheel>", self._on_mousewheel)
+        html_label.config(yscrollcommand=scrollbar.set)
 
         # Optional checkbox and callback handling
         if callback:
@@ -83,17 +81,13 @@ class MarkdownWindow:
             footer_frame.grid_columnconfigure(0, weight=1)
             footer_frame.grid_columnconfigure(1, weight=1)
             footer_frame.grid_columnconfigure(2, weight=1)
-            footer_frame.grid_columnconfigure(3, weight=0)
+            footer_frame.grid_columnconfigure(3, weight=0)  
 
         # Adjust window size based on content with constraints
-        self._adjust_window_size(self.html_label, self.scrollbar)
+        self._adjust_window_size(html_label, scrollbar)
         self._display_to_center()
         self.window.lift()
-
-    def _on_mousewheel(self, event):
-        """Handle mouse wheel events for scrolling."""
-        self.html_label.yview_scroll(-1 * (event.delta // 120), "units")
-
+    
     def _display_to_center(self):
         # Get parent window dimensions and position
         parent_x = self.parent.winfo_x()

--- a/src/FreeScribe.client/UI/MarkdownWindow.py
+++ b/src/FreeScribe.client/UI/MarkdownWindow.py
@@ -38,26 +38,28 @@ class MarkdownWindow:
         self.window.iconbitmap(get_file_path('assets', 'logo.ico'))
 
         # Footer frame to hold checkbox and close button
-        footer_frame = tk.Frame(self.window,bg="lightgray")
+        footer_frame = tk.Frame(self.window, bg="lightgray")
         footer_frame.pack(side=tk.BOTTOM, fill="x")
         # Add a version label to the footer
         version = get_application_version()
-        
 
         # Create a frame to hold the HTMLLabel and scrollbar
         frame = tk.Frame(self.window)
         frame.pack(fill="both", expand=True, padx=10, pady=10)
 
         # Create the HTMLLabel widget
-        html_label = HTMLLabel(frame, html=content)
-        html_label.pack(side="left", fill="both", expand=True)
+        self.html_label = HTMLLabel(frame, html=content)
+        self.html_label.pack(side="left", fill="both", expand=True)
 
         # Create the scrollbar
-        scrollbar = tk.Scrollbar(frame, orient="vertical", command=html_label.yview)
-        scrollbar.pack(side="right", fill="y")
+        self.scrollbar = tk.Scrollbar(frame, orient="vertical", command=self.html_label.yview)
+        self.scrollbar.pack(side="right", fill="y")
 
         # Configure the HTMLLabel to use the scrollbar
-        html_label.config(yscrollcommand=scrollbar.set)
+        self.html_label.config(yscrollcommand=self.scrollbar.set)
+
+        # Bind mouse wheel event to the HTML label
+        self.html_label.bind("<MouseWheel>", self._on_mousewheel)
 
         # Optional checkbox and callback handling
         if callback:
@@ -81,13 +83,17 @@ class MarkdownWindow:
             footer_frame.grid_columnconfigure(0, weight=1)
             footer_frame.grid_columnconfigure(1, weight=1)
             footer_frame.grid_columnconfigure(2, weight=1)
-            footer_frame.grid_columnconfigure(3, weight=0)  
+            footer_frame.grid_columnconfigure(3, weight=0)
 
         # Adjust window size based on content with constraints
-        self._adjust_window_size(html_label, scrollbar)
+        self._adjust_window_size(self.html_label, self.scrollbar)
         self._display_to_center()
         self.window.lift()
-    
+
+    def _on_mousewheel(self, event):
+        """Handle mouse wheel events for scrolling."""
+        self.html_label.yview_scroll(-1 * (event.delta // 120), "units")
+
     def _display_to_center(self):
         # Get parent window dimensions and position
         parent_x = self.parent.winfo_x()

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -793,37 +793,45 @@ class SettingsWindowUI:
         self.root.focus_force()
 
     def add_scrollbar_to_frame(self, frame):
-        # Only add scrollbar to advanced settings frame
-        if frame == self.advanced_frame:
-            canvas = tk.Canvas(frame)
-            scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
-            scrollable_frame = ttk.Frame(canvas)
+        """
+        Adds a scrollbar to a given frame.
 
-            scrollable_frame.bind(
-                "<Configure>",
-                lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
-            )
+        Args:
+            frame (tk.Frame): The frame to which the scrollbar will be added.
 
-            canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
-            canvas.configure(yscrollcommand=scrollbar.set)
-
-            canvas.pack(side="left", fill="both", expand=True)
-            scrollbar.pack(side="right", fill="y")
-
-            def _on_mousewheel(event):
-                if canvas.winfo_exists():  # Check if canvas still exists
-                    canvas.yview_scroll(int(-1*(event.delta/120)), "units")
-                    return "break"
-
-            # Bind mousewheel only when mouse is over the canvas
-            canvas.bind('<Enter>', lambda e: canvas.bind_all("<MouseWheel>", _on_mousewheel))
-            canvas.bind('<Leave>', lambda e: canvas.unbind_all("<MouseWheel>"))
-
-            return scrollable_frame
-        else:
-            # For other frames, return the frame as is without scrollbar
+        Returns:
+            tk.Frame: The scrollable frame.
+        """
+        # Guard clause: return frame as is if it's not the advanced frame
+        if frame != self.advanced_frame:
             return frame
-        
+
+        # Create scrollable frame components
+        canvas = tk.Canvas(frame)
+        scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
+        scrollable_frame = ttk.Frame(canvas)
+
+        scrollable_frame.bind(
+            "<Configure>",
+            lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+        )
+
+        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        canvas.configure(yscrollcommand=scrollbar.set)
+
+        canvas.pack(side="left", fill="both", expand=True)
+        scrollbar.pack(side="right", fill="y")
+
+        def _on_mousewheel(event):
+            if canvas.winfo_exists():  # Check if canvas still exists
+                canvas.yview_scroll(int(-1*(event.delta/120)), "units")
+                return "break"
+
+        # Bind mousewheel only when mouse is over the canvas
+        canvas.bind('<Enter>', lambda e: canvas.bind_all("<MouseWheel>", _on_mousewheel))
+        canvas.bind('<Leave>', lambda e: canvas.unbind_all("<MouseWheel>"))
+
+        return scrollable_frame      
     def close_window(self):
         """
         Cleans up the settings window.

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -792,6 +792,38 @@ class SettingsWindowUI:
         # Focus on the root window again incase lost
         self.root.focus_force()
 
+    def add_scrollbar_to_frame(self, frame):
+        # Only add scrollbar to advanced settings frame
+        if frame == self.advanced_frame:
+            canvas = tk.Canvas(frame)
+            scrollbar = ttk.Scrollbar(frame, orient="vertical", command=canvas.yview)
+            scrollable_frame = ttk.Frame(canvas)
+
+            scrollable_frame.bind(
+                "<Configure>",
+                lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
+            )
+
+            canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+            canvas.configure(yscrollcommand=scrollbar.set)
+
+            canvas.pack(side="left", fill="both", expand=True)
+            scrollbar.pack(side="right", fill="y")
+
+            def _on_mousewheel(event):
+                if canvas.winfo_exists():  # Check if canvas still exists
+                    canvas.yview_scroll(int(-1*(event.delta/120)), "units")
+                    return "break"
+
+            # Bind mousewheel only when mouse is over the canvas
+            canvas.bind('<Enter>', lambda e: canvas.bind_all("<MouseWheel>", _on_mousewheel))
+            canvas.bind('<Leave>', lambda e: canvas.unbind_all("<MouseWheel>"))
+
+            return scrollable_frame
+        else:
+            # For other frames, return the frame as is without scrollbar
+            return frame
+        
     def close_window(self):
         """
         Cleans up the settings window.


### PR DESCRIPTION
.Created a separate scroll action config for both setting page and the markdown page

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where scrolling with the mouse wheel would affect the main FreeScribe window when the help or settings windows were open.