### PR TITLE
ci(rc-tags): Make RC releases mark as pre release.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,10 +68,10 @@ jobs:
           script-file: .\scripts\install.nsi
           additional-plugin-paths: "./scripts/nsis-plugins"
 
-      - name: Check if alpha release
+      - name: Check if alpha or RC release
         id: check_alpha
         run: |
-          if ("${{ github.ref }}" -like "*.alpha") {
+          if ("${{ github.ref }}" -like "*.alpha" -or "${{ github.ref }}" -like "*-RC*") {
             echo "is_alpha=true" >> $env:GITHUB_OUTPUT
           } else {
             echo "is_alpha=false" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Mark release candidate (RC) releases as pre-releases in the release workflow by updating the conditional check in the GitHub Actions workflow to include branches with the '-RC-' tag in their name, ensuring that RC builds are correctly identified as pre-releases during the release process