### PR TITLE
fix(initial-model-load): If LLM errors out then cancel waiting for it.

### DIFF
--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -5,6 +5,13 @@ import threading
 from UI.LoadingWindow import LoadingWindow
 import tkinter.messagebox as messagebox
 from UI.SettingsConstant import SettingsKeys, DEFAULT_CONTEXT_WINDOW_SIZE
+from enum import Enum
+
+class ModelStatus(Enum):
+    """
+    Enum class for model loading status.
+    """
+    ERROR = 1
 
 
 class Model:
@@ -226,7 +233,7 @@ class ModelManager:
                 # model doesnt exist
                 #TODO: Logo to system log
                 messagebox.showerror("Model Error", f"Model failed to load. Please ensure you have a valid model selected in the settings. Currently trying to load: {os.path.abspath(model_path)}. Error received ({e.__class__.__name__}): {str(e)}")
-                ModelManager.local_model = None
+                ModelManager.local_model = ModelStatus.ERROR
 
         thread = threading.Thread(target=load_model)
         thread.start()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -57,7 +57,7 @@ from WhisperModel import TranscribeError
 from UI.Widgets.PopupBox import PopupBox
 from UI.Widgets.TimestampListbox import TimestampListbox
 from UI.ScrubWindow import ScrubWindow
-
+from Model import ModelStatus
 
 
 if os.environ.get("FREESCRIBE_DEBUG"):
@@ -2005,9 +2005,18 @@ def await_models(timeout_length=60):
     # if we are not using local llm then we can assume it is loaded and dont wait
     llm_loaded = (not app_settings.editable_settings[SettingsKeys.LOCAL_LLM.value] or ModelManager.local_model)
  
+    # if there was a error stop checking
+    if ModelManager.local_model == ModelStatus.ERROR:
+        #Error message is displayed else where
+        llm_loaded = True
+
     # wait for both models to be loaded
     if not whisper_loaded or not llm_loaded:
         print("Waiting for models to load...")
+
+        # if error null out the model
+        if ModelManager.local_model == ModelStatus.ERROR:
+            ModelManager.local_model = None
 
         # override the lock in case something else tried to edit
         window.disable_settings_menu()

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -2014,16 +2014,17 @@ def await_models(timeout_length=60):
     if not whisper_loaded or not llm_loaded:
         print("Waiting for models to load...")
 
-        # if error null out the model
-        if ModelManager.local_model == ModelStatus.ERROR:
-            ModelManager.local_model = None
-
         # override the lock in case something else tried to edit
         window.disable_settings_menu()
 
         root.after(100, await_models)
     else:
         print("*** Models loaded successfully on startup.")
+
+        # if error null out the model
+        if ModelManager.local_model == ModelStatus.ERROR:
+            ModelManager.local_model = None
+
         window.enable_settings_menu()
 
 root.after(100, await_models)


### PR DESCRIPTION
This is done to prevent infinite hang on model load failure. We also NULL it out so any future checks know its not loaded.

## Summary by Sourcery

Bug Fixes:
- Prevent infinite hangs if the local LLM fails to load by cancelling the wait and setting the model status to null if an error occurs during loading, rather than leaving it in an undefined state or retrying indefinitely.  Display an error message to the user if the model fails to load and include the path of the model that failed to load, and the error message received from the model loading process