### PR TITLE
fix: no stream handler in debug window

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -63,15 +63,18 @@ dual = DualOutput()
 sys.stdout = dual
 sys.stderr = dual
 
+
 if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG
 else:
     LOG_LEVEL = logging.INFO
 
 logging.basicConfig(
-    stream=dual,
     level=LOG_LEVEL,
-    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout)
+    ]
 )
 
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -59,6 +59,9 @@ from UI.Widgets.TimestampListbox import TimestampListbox
 from UI.ScrubWindow import ScrubWindow
 
 
+dual = DualOutput()
+sys.stdout = dual
+sys.stderr = dual
 
 if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG
@@ -66,13 +69,11 @@ else:
     LOG_LEVEL = logging.INFO
 
 logging.basicConfig(
+    stream=dual,
     level=LOG_LEVEL,
     format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
 )
 
-dual = DualOutput()
-sys.stdout = dual
-sys.stderr = dual
 
 APP_NAME = 'AI Medical Scribe'  # Application name
 APP_TASK_MANAGER_NAME = 'freescribe-client.exe'


### PR DESCRIPTION
#394

## Summary by Sourcery

Bug Fixes:
- Redirect the standard output and error streams to the debug window consistently to ensure all logs are displayed in the debug window, addressing the issue where logs were missing from the debug window