### PR TITLE
fix(startup): Fixed issues that prevented application start up on macos.

### DIFF
--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -1,6 +1,7 @@
 import tkinter as tk
 from tkinter import ttk
 from utils.file_utils import get_file_path
+import utils.system
 
 class LoadingWindow:
     """
@@ -78,8 +79,19 @@ class LoadingWindow:
                 self.popup.transient(parent)
                 
                 # Disable the parent window
-                parent.wm_attributes('-disabled', True)
-
+                # Os check because -disabled is unavail on macos
+                if utils.system.is_windows():
+                    parent.wm_attributes('-disabled', True)
+                elif utils.system.is_macos():
+                    # if not windows take a different approach 
+                    # Make window modal on macOS
+                    self.popup.transient(parent)
+                    self.popup.grab_set()
+                    
+                    # Set window to stay on top (macOS modal behavior)
+                    self.popup.attributes('-topmost', True)
+                # todo: add linux support
+                    
             # Use label and progress bar
             self.label = tk.Label(self.popup, text=initial_text)
             self.label.pack(pady=(10,5))
@@ -104,7 +116,15 @@ class LoadingWindow:
         except Exception:
             # Enable the window on exception
             if parent:
-                parent.wm_attributes('-disabled', False)
+                if utils.system.is_windows():
+                    parent.wm_attributes('-disabled', False)
+                elif utils.system.is_macos():
+                    # macos/linux
+                    # Release modal state
+                    self.popup.grab_release()
+                    # Destroy child window
+                    self.popup.destroy()
+                #TODO: Add linux support
             raise
 
     def _handle_cancel(self):
@@ -144,8 +164,12 @@ class LoadingWindow:
         if self.popup:
             # Enable the parent window
             if self.parent:
-                self.parent.wm_attributes('-disabled', False)
-            
+                if utils.system.is_windows():
+                    self.parent.wm_attributes('-disabled', False)
+                elif utils.system.is_macos():
+                    self.popup.grab_release()
+                #TODO: Add linux support
+
             if self.progress.winfo_exists():
                 self.progress.stop()
 

--- a/src/FreeScribe.client/utils/system.py
+++ b/src/FreeScribe.client/utils/system.py
@@ -1,0 +1,41 @@
+"""
+This software is released under the AGPL-3.0 license
+Copyright (c) 2023-2025 Braedon Hendy
+
+Further updates and packaging added in 2024-2025 through the ClinicianFOCUS initiative, 
+a collaboration with Dr. Braedon Hendy and Conestoga College Institute of Applied 
+Learning and Technology as part of the CNERG+ applied research project, 
+Unburdening Primary Healthcare: An Open-Source AI Clinician Partner Platform". 
+Prof. Michael Yingbull (PI), Dr. Braedon Hendy (Partner), 
+and Research Students (Software Developers) - 
+Alex Simko, Pemba Sherpa, Naitik Patel, Yogesh Kumar and Xun Zhong.
+"""
+
+import platform
+
+def is_macos():
+    """
+    Check if the current system is macOS.
+    
+    :returns bool: True if macOS, False otherwise
+    """
+    
+    return platform.system() == "Darwin"
+
+def is_windows():
+    """
+    Check if the current system is Windows.
+    
+    :returns bool: True if Windows, False otherwise
+    """
+    
+    return platform.system() == "Windows"
+
+def is_linux():
+    """
+    Check if the current system is Linux.
+    
+    :returns bool: True if Linux, False otherwise
+    """
+    
+    return platform.system() == "Linux"

--- a/src/FreeScribe.client/utils/window_utils.py
+++ b/src/FreeScribe.client/utils/window_utils.py
@@ -13,7 +13,7 @@ Alex Simko, Pemba Sherpa, Naitik Patel, Yogesh Kumar and Xun Zhong.
 
 import tkinter as tk
 import platform
-from ctypes import windll
+import ctypes
 from utils.decorators import windows_only
 
 @windows_only
@@ -42,7 +42,7 @@ def remove_min_max(window):
     WS_MAXIMIZEBOX = 0x00010000
 
     # Get current window style
-    style = windll.user32.GetWindowLongW(hwnd, GWL_STYLE)
+    style = ctypes.windll.user32.GetWindowLongW(hwnd, GWL_STYLE)
 
     # Remove minimize and maximize box styles
     style &= ~WS_MINIMIZEBOX
@@ -50,8 +50,8 @@ def remove_min_max(window):
 
     # Apply the new style
     # 0x0027 = SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAME
-    windll.user32.SetWindowLongW(hwnd, GWL_STYLE, style)
-    windll.user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 
+    ctypes.windll.user32.SetWindowLongW(hwnd, GWL_STYLE, style)
+    ctypes.windll.user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 
                                0x0027)
 
 @windows_only
@@ -73,14 +73,14 @@ def add_min_max(window):
         This function requires the windll module from ctypes and only works on Windows systems.
         The window style changes are applied immediately.
     """
-    hwnd = windll.user32.GetParent(window.winfo_id())
+    hwnd = ctypes.windll.user32.GetParent(window.winfo_id())
 
     GWL_STYLE = -16
     WS_MINIMIZEBOX = 0x00020000
     WS_MAXIMIZEBOX = 0x00010000
 
     # Get current window style
-    style = windll.user32.GetWindowLongW(hwnd, GWL_STYLE)
+    style = ctypes.windll.user32.GetWindowLongW(hwnd, GWL_STYLE)
 
     # Add minimize and maximize box styles back
     style |= WS_MINIMIZEBOX
@@ -88,6 +88,6 @@ def add_min_max(window):
 
     # Apply the new style
     # 0x0027 = SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_FRAME
-    windll.user32.SetWindowLongW(hwnd, GWL_STYLE, style)
-    windll.user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 
+    ctypes.windll.user32.SetWindowLongW(hwnd, GWL_STYLE, style)
+    ctypes.windll.user32.SetWindowPos(hwnd, 0, 0, 0, 0, 0, 
                                0x0027)


### PR DESCRIPTION
## Summary by Sourcery

Fix startup issues on macOS.  Introduce OS check to determine how to disable the parent window during startup on different operating systems.  Implement modal behavior for the loading window on macOS to prevent user interaction with the main application window until loading is complete.

Bug Fixes:
- Fixed an issue that prevented the application from starting up on macOS by changing the way the loading window disables its parent window. The loading window now correctly grabs focus and stays on top on macOS systems, preventing interaction with the parent window until loading is complete. 

Chores:
- Added a new `utils.system` module to determine the operating system (OS).