### PR TITLE
params to remove close button from warning

### DIFF
--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -129,7 +129,7 @@ class MainWindowUI:
         self._background_availbility_docker_check()
         self._background_check_container_status(llm_dot, whisper_dot)
 
-    def create_warning_bar(self, text):
+    def create_warning_bar(self, text, closeButton=True):
         """
         Create a warning bar at the bottom of the window to notify the user about microphone issues.
         
@@ -154,15 +154,17 @@ class MainWindowUI:
         )
         text_label.pack(side=tk.LEFT)
 
-        # Add a button to allow users to close the warning bar
-        close_button = tk.Button(
-            self.warning_bar,
-            text="X",
-            command=self.destroy_warning_bar,  # Call the destroy method when clicked
-            foreground="black"
-        )
+        if closeButton :
+            # Add a button to allow users to close the warning bar
+            close_button = tk.Button(
+                self.warning_bar,
+                text="X",
+                command=self.destroy_warning_bar,  # Call the destroy method when clicked
+                foreground="black"
+            )
 
-        close_button.pack(side=tk.RIGHT)
+            close_button.pack(side=tk.RIGHT)
+
 
     def destroy_warning_bar(self):
         """

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -466,9 +466,9 @@ def check_silence_warning(silence_duration):
     # Check if we need to warn if silence is long than warn time
     if silence_duration >= SILENCE_WARNING_LENGTH and window.warning_bar is None and not is_paused:
         if current_view == "full":            
-            window.create_warning_bar(f"No audio input detected for {SILENCE_WARNING_LENGTH} seconds. Please check and ensure your microphone input device is working.")
+            window.create_warning_bar(f"No audio input detected for {SILENCE_WARNING_LENGTH} seconds. Please check and ensure your microphone input device is working.", closeButton=False)
         elif current_view == "minimal":
-            window.create_warning_bar(f"🔇No audio for {SILENCE_WARNING_LENGTH}s.")
+            window.create_warning_bar(f"🔇No audio for {SILENCE_WARNING_LENGTH}s.", closeButton=False)
     elif silence_duration <= SILENCE_WARNING_LENGTH and window.warning_bar is not None:
         # If the warning bar is displayed, remove it
         window.destroy_warning_bar()


### PR DESCRIPTION
### Issue
- #404 

### Changes
- Add option to remove the close button from warning.

### Screenshots
![image](https://github.com/user-attachments/assets/8fc19587-fb53-4ba9-9daf-56e4ef89b1eb)
![image](https://github.com/user-attachments/assets/d487705a-f2b3-45da-8faf-50c7e3f1e824)

## Summary by Sourcery

This pull request introduces a new feature that allows the warning bar to be displayed without a close button. This is useful for warnings that should not be dismissed by the user, such as the silence warning.

New Features:
- Added the ability to display a warning bar without a close button.

Bug Fixes:
- The silence warning now does not have a close button.

Enhancements:
- The warning bar now has an optional close button, which can be disabled when creating the warning.