### PR TITLE
print -> log, detailed metadata of log message, not saving log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+freescribe.log.*
+*.log
 .idea/
 __version__
 

--- a/src/FreeScribe.client/ContainerManager.py
+++ b/src/FreeScribe.client/ContainerManager.py
@@ -15,10 +15,13 @@ import docker
 import asyncio
 import time
 
+from utils.log_config import logger
+
+
 class ContainerState(Enum):
     CONTAINER_STOPPED = "ContainerStopped"
     CONTAINER_STARTED = "ContainerStarted"
-    
+
 class ContainerManager:
     """
     Manages Docker containers by starting and stopping them.
@@ -107,7 +110,7 @@ class ContainerManager:
         try:
             container = self.client.containers.get(container_name)
             container.stop()
-            print(f"Container {container_name} stopped successfully.")
+            logger.info(f"Container {container_name} stopped successfully.")
             return ContainerState.CONTAINER_STOPPED
         except docker.errors.NotFound as e:
             raise docker.errors.NotFound(f"Container {container_name} not found.") from e
@@ -132,13 +135,14 @@ class ContainerManager:
             return status == "running"
 
         except docker.errors.NotFound:
-            print(f"Container {container_name} not found.")
+            logger.error(f"Container {container_name} not found.")
             return False
         except docker.errors.APIError as e:
-            print(f"An error occurred while checking the container status: {e}")
+            logger.error(f"An error occurred while checking the container status: {e}")
             return False
         except Exception as e:
-            print(f"An error occurred while checking the container status: {e}")
+            logger.exception(str(e))
+            logger.error(f"An error occurred while checking the container status: {e}")
             return False
 
     def set_status_icon_color(self, widget, status: ContainerState):

--- a/src/FreeScribe.client/ContainerManager.py
+++ b/src/FreeScribe.client/ContainerManager.py
@@ -141,7 +141,6 @@ class ContainerManager:
             logger.error(f"An error occurred while checking the container status: {e}")
             return False
         except Exception as e:
-            logger.exception(str(e))
             logger.error(f"An error occurred while checking the container status: {e}")
             return False
 

--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -5,7 +5,6 @@ import threading
 from UI.LoadingWindow import LoadingWindow
 import tkinter.messagebox as messagebox
 from UI.SettingsConstant import SettingsKeys, DEFAULT_CONTEXT_WINDOW_SIZE
-import contextlib
 from utils.log_config import logger
 
 

--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -122,7 +122,6 @@ class Model:
             return response["choices"][0]["message"]["content"]
             
         except Exception as e:
-            logger.exception(str(e))
             logger.error(f"GPU inference error ({e.__class__.__name__}): {str(e)}")
             return f"({e.__class__.__name__}): {str(e)}"
 

--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -5,6 +5,8 @@ import threading
 from UI.LoadingWindow import LoadingWindow
 import tkinter.messagebox as messagebox
 from UI.SettingsConstant import SettingsKeys, DEFAULT_CONTEXT_WINDOW_SIZE
+import contextlib
+from utils.log_config import logger
 
 
 class Model:
@@ -65,7 +67,7 @@ class Model:
                 tensor_split=tensor_split,
                 chat_format=chat_template,
             )
-        
+
             # Store configuration
             self.config = {
                 "gpu_layers": gpu_layers,
@@ -120,7 +122,8 @@ class Model:
             return response["choices"][0]["message"]["content"]
             
         except Exception as e:
-            print(f"GPU inference error ({e.__class__.__name__}): {str(e)}")
+            logger.exception(str(e))
+            logger.error(f"GPU inference error ({e.__class__.__name__}): {str(e)}")
             return f"({e.__class__.__name__}): {str(e)}"
 
     

--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -7,7 +7,7 @@ and a debug window interface built with tkinter.
 
 import tkinter as tk
 
-from utils.log_config import DualOutput
+from utils.log_config import TrioOutput
 from utils.utils import bring_to_front
 
 
@@ -81,7 +81,7 @@ class DebugPrintWindow:
         Preserves scroll position when updating content and only updates
         if there are changes in the buffer.
         """
-        content = DualOutput.get_buffer_content()
+        content = TrioOutput.get_buffer_content()
         current_content = self.text_widget.get("1.0", tk.END).strip()
 
         if content != current_content:

--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -7,7 +7,7 @@ and a debug window interface built with tkinter.
 
 import tkinter as tk
 
-from utils.log_config import TripleOutput
+from utils.log_config import BufferHandler
 from utils.utils import bring_to_front
 
 
@@ -81,7 +81,7 @@ class DebugPrintWindow:
         Preserves scroll position when updating content and only updates
         if there are changes in the buffer.
         """
-        content = TripleOutput.get_buffer_content()
+        content = BufferHandler.get_buffer_content()
         current_content = self.text_widget.get("1.0", tk.END).strip()
 
         if content != current_content:

--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -7,7 +7,7 @@ and a debug window interface built with tkinter.
 
 import tkinter as tk
 
-from utils.log_config import BufferHandler
+from utils.log_config import buffer_handler
 from utils.utils import bring_to_front
 
 
@@ -81,7 +81,7 @@ class DebugPrintWindow:
         Preserves scroll position when updating content and only updates
         if there are changes in the buffer.
         """
-        content = BufferHandler.get_buffer_content()
+        content = buffer_handler.get_buffer_content()
         current_content = self.text_widget.get("1.0", tk.END).strip()
 
         if content != current_content:

--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -7,7 +7,7 @@ and a debug window interface built with tkinter.
 
 import tkinter as tk
 
-from utils.log_config import TrioOutput
+from utils.log_config import TripleOutput
 from utils.utils import bring_to_front
 
 
@@ -81,7 +81,7 @@ class DebugPrintWindow:
         Preserves scroll position when updating content and only updates
         if there are changes in the buffer.
         """
-        content = TrioOutput.get_buffer_content()
+        content = TripleOutput.get_buffer_content()
         current_content = self.text_widget.get("1.0", tk.END).strip()
 
         if content != current_content:

--- a/src/FreeScribe.client/UI/DebugWindow.py
+++ b/src/FreeScribe.client/UI/DebugWindow.py
@@ -6,64 +6,10 @@ and a debug window interface built with tkinter.
 """
 
 import tkinter as tk
-import io
-import sys
-from datetime import datetime
-from collections import deque
+
+from utils.log_config import DualOutput
 from utils.utils import bring_to_front
 
-class DualOutput:
-    buffer = None
-    MAX_BUFFER_SIZE = 2500  # Maximum number of lines in the buffer
-
-    def __init__(self):
-        """
-        Initialize the dual output handler.
-        
-        Creates a deque buffer with a max length and stores references to original stdout/stderr streams.
-        """
-        DualOutput.buffer = deque(maxlen=DualOutput.MAX_BUFFER_SIZE)  # Buffer with a fixed size
-        self.original_stdout = sys.stdout  # Save the original stdout
-        self.original_stderr = sys.stderr  # Save the original stderr
-
-    def write(self, message):
-        """
-        Write a message to both the buffer and original stdout.
-        
-        :param message: The message to be written
-        :type message: str
-        """
-        if message.strip():
-            timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            if "\n" in message:  # Handle multi-line messages
-                for line in message.splitlines():
-                    if line.strip():
-                        formatted_message = f"{timestamp} - {line}\n"
-                        DualOutput.buffer.append(formatted_message)
-            else:
-                formatted_message = f"{timestamp} - {message}"
-                DualOutput.buffer.append(formatted_message)
-        else:
-            DualOutput.buffer.append("\n")
-        if self.original_stdout is not None:
-            self.original_stdout.write(message)
-
-    def flush(self):
-        """
-        Flush the original stdout to ensure output is written immediately.
-        """
-        if self.original_stdout is not None:
-            self.original_stdout.flush()
-
-    @staticmethod
-    def get_buffer_content():
-        """
-        Retrieve all content stored in the buffer.
-        
-        :return: The complete buffer contents as a single string.
-        :rtype: str
-        """
-        return ''.join(DualOutput.buffer)
 
 class DebugPrintWindow:
     """

--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -6,6 +6,7 @@ from UI.SettingsWindowUI import SettingsWindowUI
 from UI.MarkdownWindow import MarkdownWindow
 from utils.file_utils import get_file_path
 from UI.DebugWindow import DebugPrintWindow
+from utils.log_config import logger
 
 DOCKER_CONTAINER_CHECK_INTERVAL = 10000  # Interval in milliseconds to check the Docker container status
 DOCKER_DESKTOP_CHECK_INTERVAL = 10000  # Interval in milliseconds to check the Docker Desktop status
@@ -361,18 +362,18 @@ class MainWindowUI:
         This method is intended to be run in a separate thread to periodically
         check the availability of the Docker client.
         """
-        print("Checking Docker availability in the background...")
+        logger.info("Checking Docker availability in the background...")
         if self.logic.container_manager.check_docker_availability():
             # Enable the Docker status bar UI elements if not enabled
             if not self.is_status_bar_enabled:
                 self.enable_docker_ui()
-            print("Docker client is available.")
+            logger.info("Docker client is available.")
         else:
             # Disable the Docker status bar UI elements if not disabled
             if self.is_status_bar_enabled:
                 self.disable_docker_ui()
 
-            print("Docker client is not available.")
+            logger.info("Docker client is not available.")
 
         self.current_docker_status_check_id = self.root.after(DOCKER_DESKTOP_CHECK_INTERVAL, self._background_availbility_docker_check)
 

--- a/src/FreeScribe.client/UI/MarkdownWindow.py
+++ b/src/FreeScribe.client/UI/MarkdownWindow.py
@@ -4,6 +4,8 @@ import tkinter as tk
 from tkhtmlview import HTMLLabel
 from utils.file_utils import get_file_path
 from utils.utils import get_application_version
+from utils.log_config import logger
+
 
 class MarkdownWindow:
     """
@@ -26,7 +28,7 @@ class MarkdownWindow:
             with open(file_path, "r") as file:
                 content = md.markdown(file.read(), extensions=["extra", "smarty"])
         except FileNotFoundError:
-            print(f"File not found: {file_path}")
+            logger.error(f"File not found: {file_path}")
             messagebox.showerror("Error", "File not found")
             return
 

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -461,7 +461,6 @@ class SettingsWindow():
             settings_window.destroy()
         except Exception as e:
             # Print any exception that occurs during file handling or window destruction.
-            logger.exception(str(e))
             logger.error(f"Error clearing settings files: {e}")
             messagebox.showerror("Error", "An error occurred while clearing settings. Please try again.")
 
@@ -503,7 +502,7 @@ class SettingsWindow():
             return available_models
         except requests.RequestException as e:
             # messagebox.showerror("Error", f"Failed to fetch models: {e}. Please ensure your OpenAI API key is correct.") 
-            logger.exception(str(e))
+            logger.error(str(e))
             return ["Failed to load models", "Custom"]
 
     def update_models_dropdown(self, dropdown, endpoint=None):

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -29,6 +29,7 @@ from utils.utils import get_application_version
 from Model import ModelManager
 from utils.ip_utils import is_valid_url
 import multiprocessing
+from utils.log_config import logger
 
 
 class SettingsWindow():
@@ -268,7 +269,7 @@ class SettingsWindow():
                     self.scribe_template_values.append(title)
                     self.scribe_template_mapping[title] = (aiscribe, aiscribe2)
         except FileNotFoundError:
-            print("options.txt not found, using default values.")
+            logger.info("options.txt not found, using default values.")
             # Fallback default options if file not found
             self.scribe_template_values = ["Settings Template"]
             self.scribe_template_mapping["Settings Template"] = (self.AISCRIBE, self.AISCRIBE2)
@@ -288,7 +289,7 @@ class SettingsWindow():
                 try:
                     settings = json.load(file)
                 except json.JSONDecodeError:
-                    print("Error loading settings file. Using default settings.")
+                    logger.error("Error loading settings file. Using default settings.")
                     return self.OPENAI_API_KEY
 
                 self.OPENAI_API_KEY = settings.get("openai_api_key", self.OPENAI_API_KEY)
@@ -307,7 +308,7 @@ class SettingsWindow():
 
                 return self.OPENAI_API_KEY
         except FileNotFoundError:
-            print("Settings file not found. Using default settings.")
+            logger.info("Settings file not found. Using default settings.")
             return self.OPENAI_API_KEY
 
     def save_settings_to_file(self):
@@ -397,7 +398,7 @@ class SettingsWindow():
         open(get_resource_path('settings.txt'), 'w').close()  
         open(get_resource_path('aiscribe.txt'), 'w').close()
         open(get_resource_path('aiscribe2.txt'), 'w').close()
-        print("Settings file cleared.")
+        logger.info("Settings file cleared.")
 
     def __keep_network_clear_settings(self):
         """
@@ -425,7 +426,7 @@ class SettingsWindow():
 
         # Update the settings with the network settings
         self.editable_settings.update(settings_to_keep)
-        print("Settings file cleared except network settings.")
+        logger.info("Settings file cleared except network settings.")
 
         # Save the settings to file
         self.save_settings_to_file()
@@ -460,7 +461,8 @@ class SettingsWindow():
             settings_window.destroy()
         except Exception as e:
             # Print any exception that occurs during file handling or window destruction.
-            print(f"Error clearing settings files: {e}")
+            logger.exception(str(e))
+            logger.error(f"Error clearing settings files: {e}")
             messagebox.showerror("Error", "An error occurred while clearing settings. Please try again.")
 
     def get_available_models(self,endpoint=None):
@@ -484,7 +486,7 @@ class SettingsWindow():
 
         # url validate the endpoint
         if not is_valid_url(endpoint):
-            print("Invalid LLM Endpoint")
+            logger.info("Invalid LLM Endpoint")
             return ["Invalid LLM Endpoint", "Custom"]
 
         try:
@@ -501,7 +503,7 @@ class SettingsWindow():
             return available_models
         except requests.RequestException as e:
             # messagebox.showerror("Error", f"Failed to fetch models: {e}. Please ensure your OpenAI API key is correct.") 
-            print(e)
+            logger.exception(str(e))
             return ["Failed to load models", "Custom"]
 
     def update_models_dropdown(self, dropdown, endpoint=None):
@@ -595,19 +597,19 @@ class SettingsWindow():
             
             # If CUDA is available, set it as the default architecture to save in settings
             if Architectures.CUDA.label in architectures:
-                print("Settings file not found. Creating default settings file with CUDA architecture.")
+                logger.info("Settings file not found. Creating default settings file with CUDA architecture.")
                 self.editable_settings[SettingsKeys.WHISPER_ARCHITECTURE.value] = Architectures.CUDA.label
                 self.editable_settings[SettingsKeys.LLM_ARCHITECTURE.value] = Architectures.CUDA.label
             else:
-                print("Settings file not found. Creating default settings file.")
+                logger.info("Settings file not found. Creating default settings file.")
 
             self.save_settings_to_file()
         if not os.path.exists(get_resource_path('aiscribe.txt')):
-            print("AIScribe file not found. Creating default AIScribe file.")
+            logger.info("AIScribe file not found. Creating default AIScribe file.")
             with open(get_resource_path('aiscribe.txt'), 'w') as f:
                 f.write(self.AISCRIBE)
         if not os.path.exists(get_resource_path('aiscribe2.txt')):
-            print("AIScribe2 file not found. Creating default AIScribe2 file.")
+            logger.info("AIScribe2 file not found. Creating default AIScribe2 file.")
             with open(get_resource_path('aiscribe2.txt'), 'w') as f:
                 f.write(self.AISCRIBE2)
 

--- a/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
+++ b/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
@@ -5,6 +5,8 @@ import numpy as np
 from PIL import Image, ImageTk
 from utils.file_utils import get_file_path
 from UI.SettingsWindowUI import SettingsWindowUI
+from utils.log_config import logger
+
 
 class MicrophoneState:
     SELECTED_MICROPHONE_INDEX = None
@@ -61,7 +63,7 @@ class MicrophoneTestFrame:
             default_input_info = self.p.get_default_input_device_info()
             self.default_input_index = default_input_info['index']
         except IOError as e:
-            print(f"Failed to initialize microphone ({type(e).__name__}): {e}")
+            logger.error(f"Failed to initialize microphone ({type(e).__name__}): {e}")
             self.default_input_index = None
 
         device_count = self.p.get_device_count()
@@ -137,7 +139,7 @@ class MicrophoneTestFrame:
             mic_icon_label = ttk.Label(meter_frame, image=self.mic_photo)
             mic_icon_label.grid(row=0, column=0, padx=(5, 0), sticky='nsew')
         except Exception as e:
-            print(f"Error loading microphone icon: {e}")
+            logger.error(f"Error loading microphone icon: {e}")
 
         # Create volume meter segments
         self.segments_frame = ttk.Frame(meter_frame)
@@ -250,7 +252,7 @@ class MicrophoneTestFrame:
                 self.is_stream_active = True
             except Exception as e:
                 self.status_label.config(text="Error: Microphone not found", foreground="red")
-                print(f"Failed to open microphone ({type(e).__name__}): {e}")
+                logger.error(f"Failed to open microphone ({type(e).__name__}): {e}")
         else:
             MicrophoneState.SELECTED_MICROPHONE_INDEX = None
             MicrophoneState.SELECTED_MICROPHONE_NAME = None
@@ -267,7 +269,7 @@ class MicrophoneTestFrame:
                     self.stream.stop_stream()
                 self.stream.close()
             except Exception as e:
-                print(f"Error closing stream: {e}")
+                logger.error(f"Error closing stream: {e}")
             finally:
                 self.stream = None
                 self.is_stream_active = False
@@ -287,7 +289,7 @@ class MicrophoneTestFrame:
                 self.status_label.config(text="Microphone: Connected", foreground="green")
             except Exception as e:
                 self.status_label.config(text="Error: Microphone not found", foreground="red")
-                print(f"Failed to open microphone ({type(e).__name__}): {e}")
+                logger.error(f"Failed to open microphone ({type(e).__name__}): {e}")
 
     def update_volume_meter(self):
         """
@@ -332,7 +334,7 @@ class MicrophoneTestFrame:
                 # Handle any other stream errors
                 self.status_label.config(text="Error: Unknown Error. Check debug log for more.", foreground="red")
             
-            print(f"Error in update_volume_meter({type(e).__name__}): {e}")
+            logger.info(f"Error in update_volume_meter({type(e).__name__}): {e}")
             self.is_stream_active = False
             self.stream = None
             for segment in self.segments:
@@ -340,6 +342,7 @@ class MicrophoneTestFrame:
 
         self.frame.after(50, self.update_volume_meter)
 
+    @staticmethod
     def get_selected_microphone_index():
         """
         Get the selected microphone index.
@@ -394,6 +397,6 @@ class MicrophoneTestFrame:
                     self.stream.stop_stream()
                 self.stream.close()
             except Exception as e:
-                print(f"Error closing stream in destructor: {e}")
+                logger.error(f"Error closing stream in destructor: {e}")
         if self.p:
             self.p.terminate()

--- a/src/FreeScribe.client/UI/Widgets/TimestampListbox.py
+++ b/src/FreeScribe.client/UI/Widgets/TimestampListbox.py
@@ -1,6 +1,7 @@
 import logging
 import tkinter as tk
 import tkinter.messagebox as messagebox
+from utils.log_config import logger
 
 
 class TimestampListbox(tk.Listbox):
@@ -106,7 +107,7 @@ class TimestampListbox(tk.Listbox):
             messagebox.showwarning("Invalid Input", f"Invalid timestamp format: {str(e)}")
         except Exception as e:
             # Log unexpected errors and re-raise them
-            logging.error(f"Critical error while confirming timestamp edit: {str(e)}")
+            logger.error(f"Critical error while confirming timestamp edit: {str(e)}")
             raise  # Re-raise unexpected exceptions to prevent silent failures
 
     def cancel_edit(self):
@@ -131,5 +132,5 @@ class TimestampListbox(tk.Listbox):
             messagebox.showwarning("Invalid Input", f"Invalid timestamp format: {str(e)}")
         except Exception as e:
             # Log unexpected errors and re-raise them
-            logging.error(f"Critical error while confirming timestamp edit: {str(e)}")
+            logger.error(f"Critical error while confirming timestamp edit: {str(e)}")
             raise  # Re-raise unexpected exceptions to prevent silent failures

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -57,6 +57,7 @@ from utils.log_config import logger
 
 APP_NAME = 'AI Medical Scribe'  # Application name
 APP_TASK_MANAGER_NAME = 'freescribe-client.exe'
+logger.info(f"{APP_NAME=} {APP_TASK_MANAGER_NAME=} {get_application_version()=}")
 
 # check if another instance of the application is already running.
 # if false, create a new instance of the application
@@ -1933,6 +1934,7 @@ footer_frame.grid(row=100, column=0, columnspan=100, sticky="ew")  # Use grid in
 # Add "Version 2" label in the center of the footer
 version = get_application_version()
 version_label = tk.Label(footer_frame, text=f"FreeScribe Client {version}",bg="lightgray",fg="black").pack(side="left", expand=True, padx=2, pady=5)
+
 
 window.update_aiscribe_texts(None)
 # Bind Alt+P to send_and_receive function

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -63,15 +63,18 @@ dual = DualOutput()
 sys.stdout = dual
 sys.stderr = dual
 
+
 if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG
 else:
     LOG_LEVEL = logging.INFO
 
 logging.basicConfig(
-    stream=dual,
     level=LOG_LEVEL,
-    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
+    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout)
+    ]
 )
 
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -59,6 +59,9 @@ from UI.Widgets.TimestampListbox import TimestampListbox
 from UI.ScrubWindow import ScrubWindow
 
 
+dual = DualOutput()
+sys.stdout = dual
+sys.stderr = dual
 
 if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG
@@ -66,13 +69,11 @@ else:
     LOG_LEVEL = logging.INFO
 
 logging.basicConfig(
+    stream=dual,
     level=LOG_LEVEL,
     format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
 )
 
-dual = DualOutput()
-sys.stdout = dual
-sys.stderr = dual
 
 APP_NAME = 'AI Medical Scribe'  # Application name
 APP_TASK_MANAGER_NAME = 'freescribe-client.exe'

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -13,30 +13,26 @@ and Research Students - Software Developer Alex Simko, Pemba Sherpa (F24), and N
 
 import ctypes
 import io
-import logging
 import sys
 import gc
 import os
 from pathlib import Path
 import wave
 import threading
-import base64
 import json
 import datetime
 import re
 import time
 import queue
 import atexit
-import traceback
 import torch
 import pyaudio
 import requests
 import pyperclip
-import speech_recognition as sr # python package is named speechrecognition
 import scrubadub
 import numpy as np
 import tkinter as tk
-from tkinter import scrolledtext, ttk, filedialog
+from tkinter import ttk, filedialog
 import tkinter.messagebox as messagebox
 from faster_whisper import WhisperModel
 from UI.MainWindowUI import MainWindowUI
@@ -49,33 +45,14 @@ from utils.ip_utils import is_private_ip
 from utils.file_utils import get_file_path, get_resource_path
 from utils.OneInstance import OneInstance
 from utils.utils import get_application_version
-from UI.DebugWindow import DualOutput
 from UI.Widgets.MicrophoneTestFrame import MicrophoneTestFrame
-from utils.utils import window_has_running_instance, bring_to_front, close_mutex
+from utils.utils import close_mutex
 from utils.window_utils import remove_min_max, add_min_max
 from WhisperModel import TranscribeError
 from UI.Widgets.PopupBox import PopupBox
 from UI.Widgets.TimestampListbox import TimestampListbox
 from UI.ScrubWindow import ScrubWindow
-
-
-dual = DualOutput()
-sys.stdout = dual
-sys.stderr = dual
-
-
-if os.environ.get("FREESCRIBE_DEBUG"):
-    LOG_LEVEL = logging.DEBUG
-else:
-    LOG_LEVEL = logging.INFO
-
-logging.basicConfig(
-    level=LOG_LEVEL,
-    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout)
-    ]
-)
+from utils.log_config import logger
 
 
 APP_NAME = 'AI Medical Scribe'  # Application name
@@ -102,10 +79,10 @@ def delete_temp_file(filename):
     file_path = get_resource_path(filename)
     if os.path.exists(file_path):
         try:
-            print(f"Deleting temporary file: {filename}")
+            logger.info(f"Deleting temporary file: {filename}")
             os.remove(file_path)
         except OSError as e:
-            print(f"Error deleting temporary file {filename}: {e}")
+            logger.error(f"Error deleting temporary file {filename}: {e}")
 
 def on_closing():
     delete_temp_file('recording.wav')
@@ -249,12 +226,12 @@ def threaded_check_stt_model():
     
     # Check if the task was canceled via task_cancel_var
     if task_cancel_var.get():
-        logging.debug(f"double checking canceled")
+        logger.debug(f"double checking canceled")
         return False
     return True
 
 def threaded_toggle_recording():
-    logging.debug(f"*** Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
+    logger.debug(f"*** Toggle Recording - Recording status: {is_recording}, STT local model: {stt_local_model}")
     ready_flag = threaded_check_stt_model()
     # there is no point start recording if we are using local STT model and it's not ready
     # if user chooses to cancel the double check process, we need to return and not start recording
@@ -265,17 +242,17 @@ def threaded_toggle_recording():
 
 
 def double_check_stt_model_loading(task_done_var, task_cancel_var):
-    print(f"*** Double Checking STT model - Model Current Status: {stt_local_model}")
+    logger.info(f"*** Double Checking STT model - Model Current Status: {stt_local_model}")
     stt_loading_window = None
     try:
         if is_recording:
-            print("*** Recording in progress, skipping double check")
+            logger.info("*** Recording in progress, skipping double check")
             return
         if not app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]:
-            print("*** Local Whisper is disabled, skipping double check")
+            logger.info("*** Local Whisper is disabled, skipping double check")
             return
         if stt_local_model:
-            print("*** STT model already loaded, skipping double check")
+            logger.info("*** STT model already loaded, skipping double check")
             return
         # if using local whisper and model is not loaded, when starting recording
         if stt_model_loading_thread_lock.locked():
@@ -290,7 +267,7 @@ def double_check_stt_model_loading(task_done_var, task_cancel_var):
                 time.sleep(0.1)
                 if task_cancel_var.get():
                     # user cancel
-                    logging.debug(f"user canceled after {time.monotonic() - time_start} seconds")
+                    logger.debug(f"user canceled after {time.monotonic() - time_start} seconds")
                     return
                 if time.monotonic() - time_start > timeout:
                     messagebox.showerror("Error",
@@ -308,11 +285,11 @@ def double_check_stt_model_loading(task_done_var, task_cancel_var):
             t.join()
 
     except Exception as e:
-        logging.exception(str(e))
+        logger.exception(str(e))
         messagebox.showerror("Error",
                              f"An error occurred while loading Speech to Text model synchronously {type(e).__name__}: {e}")
     finally:
-        print(f"*** Double Checking STT model Complete - Model Current Status: {stt_local_model}")
+        logger.info(f"*** Double Checking STT model Complete - Model Current Status: {stt_local_model}")
         if stt_loading_window:
             stt_loading_window.destroy()
         task_done_var.set(True)
@@ -380,7 +357,7 @@ def open_microphone_stream():
     except (OSError, IOError) as e:
         # Log the error message
         # TODO System logger
-        print(f"An error occurred opening the stream({type(e).__name__}): {e}")
+        logger.error(f"An error occurred opening the stream({type(e).__name__}): {e}")
         return None, e
 
 def record_audio():
@@ -453,7 +430,7 @@ def record_audio():
         # Log the error message
         # TODO System logger
         # For now general catch on any problems
-        print(f"An error occurred: {e}")
+        logger.error(f"An error occurred: {e}")
     finally:
         if stream:
             stream.stop_stream()
@@ -509,10 +486,10 @@ def realtime_text():
             if audio_data is None:
                 break
             if app_settings.editable_settings[SettingsKeys.WHISPER_REAL_TIME.value] == True:
-                print("Real Time Audio to Text")
+                logger.info("Real Time Audio to Text")
                 audio_buffer = np.frombuffer(audio_data, dtype=np.int16).astype(np.float32) / 32768
                 if app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] == True:
-                    print("Local Real Time Whisper")
+                    logger.info("Local Real Time Whisper")
                     if stt_local_model is None:
                         update_gui("Local Whisper model not loaded. Please check your settings.")
                         break
@@ -524,7 +501,7 @@ def realtime_text():
                     if not local_cancel_flag and not is_audio_processing_realtime_canceled.is_set():
                         update_gui(result)
                 else:
-                    print("Remote Real Time Whisper")
+                    logger.info("Remote Real Time Whisper")
                     buffer = io.BytesIO()
                     with wave.open(buffer, 'wb') as wf:
                         wf.setnchannels(CHANNELS)
@@ -550,13 +527,13 @@ def realtime_text():
                     try:
                         verify = not app_settings.editable_settings[SettingsKeys.S2T_SELF_SIGNED_CERT.value]
 
-                        print("Sending audio to server")
-                        print("File informaton")
-                        print("File Size: ", len(buffer.getbuffer()), "bytes")
+                        logger.info("Sending audio to server")
+                        logger.info("File informaton")
+                        logger.info(f"File Size: {len(buffer.getbuffer())} bytes")
 
                         response = requests.post(app_settings.editable_settings[SettingsKeys.WHISPER_ENDPOINT.value], headers=headers,files=files, verify=verify, data=body)
                             
-                        print("Response from whisper with status code: ", response.status_code)
+                        logger.info(f"Response from whisper with status code: {response.status_code}")
 
                         if response.status_code == 200:
                             text = response.json()['text']
@@ -649,7 +626,7 @@ def toggle_recording():
                 except Exception as e:
                     # Log the error message
                     # TODO System logger
-                    print(f"An error occurred: {e}")
+                    logger.error(f"An error occurred: {e}")
                 finally:
                     REALTIME_TRANSCRIBE_THREAD_ID = None
 
@@ -678,7 +655,7 @@ def toggle_recording():
 
                 # check if we should print a message every 5 seconds 
                 if timeout_timer % 5 == 0:
-                    print(f"Waiting for audio processing to finish. Timeout after {timeout_length} seconds. Timer: {timeout_timer}s")
+                    logger.info(f"Waiting for audio processing to finish. Timeout after {timeout_length} seconds. Timer: {timeout_timer}s")
                 
                 # Wait for 100ms before checking again, to avoid busy waiting
                 time.sleep(0.1)
@@ -689,7 +666,7 @@ def toggle_recording():
 
         save_audio()
 
-        print("*** Recording Stopped")
+        logger.info("*** Recording Stopped")
         stop_flashing()
 
         if current_view == "full":
@@ -726,7 +703,7 @@ def cancel_processing():
     
     Sets the global flag to stop audio processing operations.
     """
-    print("Processing canceled.")
+    logger.info("Processing canceled.")
 
     if app_settings.editable_settings[SettingsKeys.WHISPER_REAL_TIME.value]:
         is_audio_processing_realtime_canceled.set() # Flag to terminate processing
@@ -759,7 +736,7 @@ def reset_recording_status():
         except Exception as e:
             # Log the error message
             # TODO System logger
-            print(f"An error occurred: {e}")
+            logger.error(f"An error occurred: {e}")
         finally:
             REALTIME_TRANSCRIBE_THREAD_ID = None
 
@@ -769,7 +746,7 @@ def reset_recording_status():
         except Exception as e:
             # Log the error message
             # TODO System logger
-            print(f"An error occurred: {e}")
+            logger.error(f"An error occurred: {e}")
         finally:
             GENERATION_THREAD_ID = None
 
@@ -846,7 +823,7 @@ def send_audio_to_server():
         except Exception as e:
             # Log the error message
             #TODO Logging the message to system logger
-            print(f"An error occurred: {e}")
+            logger.error(f"An error occurred: {e}")
         finally:
             GENERATION_THREAD_ID = None
             clear_application_press()
@@ -857,7 +834,7 @@ def send_audio_to_server():
     # Check if SettingsKeys.LOCAL_WHISPER is enabled in the editable settings
     if app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value] == True:
         # Inform the user that SettingsKeys.LOCAL_WHISPER.value is being used for transcription
-        print(f"Using {SettingsKeys.LOCAL_WHISPER.value} for transcription.")
+        logger.info(f"Using {SettingsKeys.LOCAL_WHISPER.value} for transcription.")
         # Configure the user input widget to be editable and clear its content
         user_input.scrolled_text.configure(state='normal')
         user_input.scrolled_text.delete("1.0", tk.END)
@@ -894,7 +871,7 @@ def send_audio_to_server():
         except Exception as e:
             # Log the error message
             # TODO: Add system eventlogger
-            print(f"An error occurred: {e}")
+            logger.error(f"An error occurred: {e}")
 
             #log error to input window
             user_input.scrolled_text.configure(state='normal')
@@ -906,7 +883,7 @@ def send_audio_to_server():
             
     else:
         # Inform the user that Remote Whisper is being used for transcription
-        print("Using Remote Whisper for transcription.")
+        logger.info("Using Remote Whisper for transcription.")
 
         # Configure the user input widget to be editable and clear its content
         user_input.scrolled_text.configure(state='normal')
@@ -943,15 +920,15 @@ def send_audio_to_server():
             try:
                 verify = not app_settings.editable_settings[SettingsKeys.S2T_SELF_SIGNED_CERT.value]
 
-                print("Sending audio to server")
-                print("File informaton")
-                print(f"File: {file_to_send}")
-                print("File Size: ", os.path.getsize(file_to_send))
+                logger.info("Sending audio to server")
+                logger.info("File informaton")
+                logger.info(f"File: {file_to_send}")
+                logger.info(f"File Size: {os.path.getsize(file_to_send)}")
 
                 # Send the request without verifying the SSL certificate
                 response = requests.post(app_settings.editable_settings[SettingsKeys.WHISPER_ENDPOINT.value], headers=headers, files=files, verify=verify, data=body)
 
-                print("Response from whisper with status code: ", response.status_code)
+                logger.info(f"Response from whisper with status code: {response.status_code}")
 
                 response.raise_for_status()
 
@@ -968,7 +945,7 @@ def send_audio_to_server():
             except Exception as e:
                 # log error message
                 #TODO: Implment proper logging to system
-                print(f"An error occurred: {e}")
+                logger.error(f"An error occurred: {e}")
                 # Display an error message to the user
                 user_input.scrolled_text.configure(state='normal')
                 user_input.scrolled_text.delete("1.0", tk.END)
@@ -995,7 +972,7 @@ def kill_thread(thread_id):
     :raises ValueError: If the thread ID is invalid.
     :raises SystemError: If the operation fails due to an unexpected state.
     """
-    print("*** Attempting to kill thread with ID:", thread_id)
+    logger.info(f"*** Attempting to kill thread with ID: {thread_id}")
     # Call the C function `PyThreadState_SetAsyncExc` to asynchronously raise
     # an exception in the target thread's context.
     res = ctypes.pythonapi.PyThreadState_SetAsyncExc(
@@ -1013,7 +990,7 @@ def kill_thread(thread_id):
         ctypes.pythonapi.PyThreadState_SetAsyncExc(thread_id, None)
         raise SystemError("PyThreadState_SetAsyncExc failed")
     
-    print("*** Killed thread with ID:", thread_id)
+    logger.info(f"*** Killed thread with ID: {thread_id}")
 
 def send_and_receive():
     global use_aiscribe, user_message
@@ -1112,7 +1089,7 @@ def send_text_to_api(edited_text):
         if app_settings.editable_settings["best_of"]:
             payload["best_of"] = int(app_settings.editable_settings["best_of"])
 
-        print(f"Error parsing settings: {e}. Using default settings.")
+        logger.info(f"Error parsing settings: {e}. Using default settings.")
 
     try:
 
@@ -1183,7 +1160,7 @@ def screen_input_with_llm(conversation):
         words = conversation.split()
         # Split the words into chunks
         chunks = [' '.join(words[i:i + words_per_chunk]) for i in range(0, len(words), words_per_chunk)]
-        print(f"Total chunks count: {len(chunks)}")
+        logger.info(f"Total chunks count: {len(chunks)}")
         # Process each chunk sequentially
         for chunk in chunks:                               
             if process_chunk(chunk):
@@ -1222,7 +1199,7 @@ def has_more_than_50_words(text: str) -> bool:
         # Split the text into words using whitespace as the delimiter
         words = text.split()        
         # Print the number of words
-        print(f"Number of words: {len(words)}")
+        logger.info(f"Number of words: {len(words)}")
         # Check if the number of words is greater than 50
         if len(words) > 50:
             # Perform AI-based prescreening
@@ -1332,7 +1309,7 @@ def generate_note(formatted_message):
             except Exception as e:
                 #Logg
                 #TODO: Implement proper logging to system event logger
-                print(f"An error occurred: {e}")
+                logger.error(f"An error occurred: {e}")
                 display_text(f"An error occurred: {e}")
                 return False
 
@@ -1386,7 +1363,7 @@ def generate_note_thread(text: str):
         except Exception as e:
             # Log the error message
             # TODO implment system logger
-            print(f"An error occurred: {e}")
+            logger.error(f"An error occurred: {e}")
         finally:
             GENERATION_THREAD_ID = None
             stop_flashing()
@@ -1709,7 +1686,7 @@ def _load_stt_model_thread():
         stt_loading_window = LoadingWindow(root, title="Speech to Text", initial_text=f"Loading Speech to Text {model_name} model. Please wait.", 
                             note_text="Note: If this is the first time loading the model, it will be actively downloading and may take some time.\n We appreciate your patience!",on_cancel=on_cancel_whisper_load)
         window.disable_settings_menu()
-        print(f"Loading STT model: {model_name}")
+        logger.info(f"Loading STT model: {model_name}")
 
         try:
             unload_stt_model()
@@ -1729,15 +1706,15 @@ def _load_stt_model_thread():
                 compute_type=compute_type
             )
 
-            print("STT model loaded successfully.")
+            logger.info("STT model loaded successfully.")
         except Exception as e:
-            print(f"An error occurred while loading STT {type(e).__name__}: {e}")
+            logger.error(f"An error occurred while loading STT {type(e).__name__}: {e}")
             stt_local_model = None
             messagebox.showerror("Error", f"An error occurred while loading Speech to Text {type(e).__name__}: {e}")
         finally:
             window.enable_settings_menu()
             stt_loading_window.destroy()
-            print("Closing STT loading window.")
+            logger.info("Closing STT loading window.")
 
 def unload_stt_model():
     """
@@ -1748,13 +1725,13 @@ def unload_stt_model():
     """
     global stt_local_model
     if stt_local_model is not None:
-        print("Unloading STT model from device.")
+        logger.info("Unloading STT model from device.")
         # no risk of temporary "stt_local_model in globals() is False" with same gc effect
         stt_local_model = None
         gc.collect()
-        print("STT model unloaded successfully.")
+        logger.info("STT model unloaded successfully.")
     else:
-        print("STT model is already unloaded.")
+        logger.info("STT model is already unloaded.")
 
 def get_selected_whisper_architecture():
     """
@@ -1812,7 +1789,7 @@ def faster_whisper_transcribe(audio):
         return "".join(f"{segment.text} " for segment in segments)
     except Exception as e:
         error_message = f"Transcription failed: {str(e)}"
-        print(f"Error during transcription: {str(e)}")
+        logger.error(f"Error during transcription: {str(e)}")
         raise TranscribeError(error_message) from e
 
 def set_cuda_paths():
@@ -1978,7 +1955,7 @@ if app_settings.editable_settings[SettingsKeys.LOCAL_LLM.value]:
 
 if app_settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]:
     # Inform the user that Local Whisper is being used for transcription
-    print("Using Local Whisper for transcription.")
+    logger.info("Using Local Whisper for transcription.")
     root.after(100, lambda: (load_stt_model()))
 
 # wait for both whisper and llm to be loaded before unlocking the settings button
@@ -1995,7 +1972,7 @@ def await_models(timeout_length=60):
     """
     #if we cancel this thread then break out of the loop
     if cancel_await_thread.is_set():
-        print("*** Model loading cancelled. Enabling settings bar.")
+        logger.info("*** Model loading cancelled. Enabling settings bar.")
         #reset the flag
         cancel_await_thread.clear()
         #reset the settings bar
@@ -2011,14 +1988,14 @@ def await_models(timeout_length=60):
  
     # wait for both models to be loaded
     if not whisper_loaded or not llm_loaded:
-        print("Waiting for models to load...")
+        logger.info("Waiting for models to load...")
 
         # override the lock in case something else tried to edit
         window.disable_settings_menu()
 
         root.after(100, await_models)
     else:
-        print("*** Models loaded successfully on startup.")
+        logger.info("*** Models loaded successfully on startup.")
         window.enable_settings_menu()
 
 root.after(100, await_models)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -226,7 +226,7 @@ def threaded_check_stt_model():
     
     # Check if the task was canceled via task_cancel_var
     if task_cancel_var.get():
-        logger.debug(f"double checking canceled")
+        logger.debug("double checking canceled")
         return False
     return True
 

--- a/src/FreeScribe.client/utils/OneInstance.py
+++ b/src/FreeScribe.client/utils/OneInstance.py
@@ -9,9 +9,7 @@ import os
 import platform
 import subprocess
 import time
-
-
-logger = logging.getLogger(__name__)
+from utils.log_config import logger
 
 
 class OneInstance:

--- a/src/FreeScribe.client/utils/decorators.py
+++ b/src/FreeScribe.client/utils/decorators.py
@@ -12,6 +12,8 @@ Alex Simko, Pemba Sherpa, Naitik Patel, Yogesh Kumar and Xun Zhong.
 """
 
 import platform
+from utils.log_config import logger
+
 
 def windows_only(func):
     """Decorator to ensure a function only runs on Windows systems.
@@ -24,7 +26,7 @@ def windows_only(func):
     """
     def wrapper(*args, **kwargs):
         if platform.system() != "Windows":
-            print("This feature is only supported on Windows.")
+            logger.info("This feature is only supported on Windows.")
             return
         return func(*args, **kwargs)
     return wrapper

--- a/src/FreeScribe.client/utils/file_utils.py
+++ b/src/FreeScribe.client/utils/file_utils.py
@@ -39,6 +39,7 @@ def get_resource_path(filename: str) -> str:
     else:
         return os.path.abspath(filename)
 
+
 def _get_user_data_dir() -> str:
     """
     Get the user data directory for the current platform.
@@ -56,5 +57,5 @@ def _get_user_data_dir() -> str:
         path = os.environ.get("XDG_DATA_HOME", "")
         if not path.strip():
             path = os.path.expanduser("~/.local/share") 
-        return self._append_app_name_and_version(path)
+        return path
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -71,8 +71,6 @@ class TripleOutput:
 
         :param log_func: The logging function to use for output (e.g., logger.info)
         :type log_func: callable
-        
-        Creates a deque buffer with a max length and stores references to original stdout/stderr streams.
         """
         self.log_func = log_func
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -106,6 +106,9 @@ class TripleOutput:
         return '\n'.join(TripleOutput.buffer)
 
 
+# Define custom level
+DIAGNOSE_LEVEL = 99
+logging.addLevelName(DIAGNOSE_LEVEL, "DIAG")
 # Configure logging
 if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG
@@ -116,9 +119,9 @@ LOG_FILE_NAME = get_resource_path("freescribe.log")
 LOG_FILE_MAX_SIZE = 10 * 1024 * 1024
 # Keep up to 1 backup log files
 LOG_FILE_BACKUP_COUNT = 1
+LOG_FORMAT = '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
 
-
-formatter = logging.Formatter('%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
+formatter = logging.Formatter(LOG_FORMAT)
 
 if sys.stderr or sys.stdout:
     console_handler = SafeStreamHandler(sys.stderr or sys.stdout)
@@ -136,10 +139,13 @@ buffer_handler.setLevel(LOG_LEVEL)
 buffer_handler.setFormatter(formatter)
 
 # root logger settings
-logging.basicConfig(level=LOG_LEVEL, handlers=[console_handler, file_handler, buffer_handler])
+logging.basicConfig(
+    level=logging.DEBUG,
+    handlers=[console_handler, file_handler, buffer_handler],
+    format=LOG_FORMAT
+)
 logger = logging.getLogger("freescribe")
 logger.setLevel(LOG_LEVEL)
 
-triple = TripleOutput(logger.info)
-sys.stdout = triple
-sys.stderr = triple
+sys.stdout = TripleOutput(logger.info)
+sys.stderr = TripleOutput(lambda msg: logger.log(DIAGNOSE_LEVEL, msg))

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -30,7 +30,7 @@ class TripleOutput:
     MAX_BUFFER_SIZE = 2500  # Maximum number of lines in the buffer
     buffer = deque(maxlen=MAX_BUFFER_SIZE)
 
-    def __init__(self, logger, level):
+    def __init__(self, log_func):
         """Initialize the triple output handler.
 
         Args:
@@ -42,8 +42,7 @@ class TripleOutput:
         # DualOutput.buffer = deque(maxlen=DualOutput.MAX_BUFFER_SIZE)  # Buffer with a fixed size
         self.original_stdout = sys.__stdout__  # Save the original stdout
         self.original_stderr = sys.__stderr__  # Save the original stderr
-        self.logger = logger
-        self.level = level
+        self.log_func = log_func
 
     def write(self, message):
         """Write a message to the buffer, original stdout, and log file.
@@ -60,24 +59,9 @@ class TripleOutput:
             return
         if '\n' in message:
             for line in message.split('\n'):
-                self._triple_write(line)
+                self.log_func(line)
             return
-        self._triple_write(message)
-
-    def _triple_write(self, msg):
-        """Internal method to write a single message to all three outputs.
-
-        Args:
-            msg (str): The message to write
-
-        Writes to:
-            - Logger at configured level
-            - Buffer
-            - Original stdout
-        """
-        self.logger.log(self.level, msg)
-        self.buffer.append(msg)
-        self.original_stdout.write(msg)
+        self.log_func(message)
 
     def flush(self):
         """Flush the original stdout to ensure output is written immediately.
@@ -135,6 +119,6 @@ logger.addHandler(console_handler)
 logger.addHandler(file_handler)
 logger.addHandler(buffer_handler)
 
-triple = TripleOutput(logger, LOG_LEVEL)
+triple = TripleOutput(logger.info)
 sys.stdout = triple
 sys.stderr = triple

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -8,27 +8,41 @@ from utils.file_utils import get_resource_path
 
 
 class SafeStreamHandler(logging.StreamHandler):
+    """A safe stream handler that checks stream state before operations.
+    
+    This handler extends logging.StreamHandler to prevent errors when
+    working with potentially closed streams.
+    """
     def emit(self, record):
+        """Emit a record if the stream is open.
+        
+        :param record: The log record to emit
+        :type record: logging.LogRecord
+        """
         if self.stream and not self.stream.closed:
             super().emit(record)
 
     def close(self):
+        """Close the handler only if the stream is open.
+        
+        Prevents errors when closing already-closed streams.
+        """
         if self.stream and not self.stream.closed:  # Only close if open
             super().close()
 
 
 class BufferHandler(logging.Handler):
-    """
-    A custom logging handler that writes log messages to the TrioOutput buffer.
+    """A custom logging handler that writes log messages to the TrioOutput buffer.
+    
+    This handler captures log records and writes them to an in-memory buffer
+    maintained by the TripleOutput class.
     """
     def emit(self, record):
         """Emit a record by writing it to the TrioOutput buffer.
 
-        Args:
-            record (logging.LogRecord): The log record to be written
-
-        Note:
-            Any exceptions during emission are handled by the parent class's handleError method
+        :param record: The log record to be written
+        :type record: logging.LogRecord
+        :note: Any exceptions during emission are handled by the parent class's handleError method
         """
         try:
             msg = self.format(record)
@@ -44,10 +58,9 @@ class TripleOutput:
     def __init__(self, log_func):
         """Initialize the triple output handler.
 
-        Args:
-            logger (logging.Logger): The logger instance to use for logging
-            level (int): The logging level to use for output
-
+        :param log_func: The logging function to use for output (e.g., logger.info)
+        :type log_func: callable
+        
         Creates a deque buffer with a max length and stores references to original stdout/stderr streams.
         """
         # DualOutput.buffer = deque(maxlen=DualOutput.MAX_BUFFER_SIZE)  # Buffer with a fixed size
@@ -58,10 +71,9 @@ class TripleOutput:
     def write(self, message):
         """Write a message to the buffer, original stdout, and log file.
 
-        Args:
-            message (str): The message to be written
-
-        Note:
+        :param message: The message to be written
+        :type message: str
+        :note: 
             - Empty messages are ignored
             - Multi-line messages are split and written line by line
         """
@@ -85,9 +97,8 @@ class TripleOutput:
     def flush(self):
         """Flush the original stdout to ensure output is written immediately.
 
-        Note:
-            This is required to maintain proper stream behavior and ensure
-            output appears in real-time
+        :note: This is required to maintain proper stream behavior and ensure
+               output appears in real-time
         """
         if self.original_stdout is not None:
             self.original_stdout.flush()
@@ -96,12 +107,10 @@ class TripleOutput:
     def get_buffer_content():
         """Retrieve all content stored in the buffer.
 
-        Returns:
-            str: The complete buffer contents as a single string with newline separators
-
-        Note:
-            The buffer maintains a fixed size (MAX_BUFFER_SIZE) and automatically
-            discards oldest entries when full
+        :return: The complete buffer contents as a single string with newline separators
+        :rtype: str
+        :note: The buffer maintains a fixed size (MAX_BUFFER_SIZE) and automatically
+               discards oldest entries when full
         """
         return '\n'.join(TripleOutput.buffer)
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -1,0 +1,25 @@
+import os
+import logging
+
+
+# Configure logging
+if os.environ.get("FREESCRIBE_DEBUG"):
+    LOG_LEVEL = logging.DEBUG
+else:
+    LOG_LEVEL = logging.INFO
+LOG_FILE_NAME = "../freescribe.log"
+# 10 MB
+LOG_FILE_MAX_SIZE = 10 * 1024 * 1024
+# Keep up to 1 backup log files
+LOG_FILE_BACKUP_COUNT = 1
+
+logging.basicConfig(
+    level=LOG_LEVEL,
+    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.StreamHandler(sys.stdout),
+        RotatingFileHandler(LOG_FILE_NAME, maxBytes=LOG_FILE_MAX_SIZE, backupCount=LOG_FILE_BACKUP_COUNT)
+    ]
+)
+
+logger = logging.getLogger(__name__)

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -176,10 +176,6 @@ else:
 console_handler.setLevel(LOG_LEVEL)
 console_handler.setFormatter(formatter)
 
-file_handler = RotatingFileHandler(LOG_FILE_NAME, maxBytes=LOG_FILE_MAX_SIZE, backupCount=LOG_FILE_BACKUP_COUNT)
-file_handler.setLevel(LOG_LEVEL)
-file_handler.setFormatter(formatter)
-
 buffer_handler = BufferHandler()
 buffer_handler.setLevel(LOG_LEVEL)
 buffer_handler.setFormatter(formatter)

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -116,7 +116,7 @@ LOG_FILE_NAME = get_resource_path("freescribe.log")
 LOG_FILE_MAX_SIZE = 10 * 1024 * 1024
 # Keep up to 1 backup log files
 LOG_FILE_BACKUP_COUNT = 1
-LOG_FORMAT = '%(asctime)s - %(levelname)s - %(threadName)s - %(name)s - [%(filename)s:%(lineno)d in %(funcName)s] - %(message)s'
+LOG_FORMAT = '[%(asctime)s] | %(levelname)s | %(threadName)s | %(name)s | [%(filename)s:%(lineno)d in %(funcName)s] | %(message)s'
 
 formatter = logging.Formatter(LOG_FORMAT)
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -17,12 +17,12 @@ class BufferHandler(logging.Handler):
         """
         try:
             msg = self.format(record)
-            TrioOutput.buffer.append(msg)
+            TripleOutput.buffer.append(msg)
         except Exception:
             self.handleError(record)
 
 
-class TrioOutput:
+class TripleOutput:
     MAX_BUFFER_SIZE = 2500  # Maximum number of lines in the buffer
     buffer = deque(maxlen=MAX_BUFFER_SIZE)
 
@@ -49,7 +49,7 @@ class TrioOutput:
         if not message:
             return
         self.logger.log(self.level, message)
-        TrioOutput.buffer.append(message)
+        TripleOutput.buffer.append(message)
         self.original_stdout.write(message)
 
     def flush(self):
@@ -67,7 +67,7 @@ class TrioOutput:
         :return: The complete buffer contents as a single string.
         :rtype: str
         """
-        return '\n'.join(TrioOutput.buffer)
+        return '\n'.join(TripleOutput.buffer)
 
 
 # Configure logging
@@ -102,6 +102,6 @@ logger.addHandler(console_handler)
 logger.addHandler(file_handler)
 logger.addHandler(buffer_handler)
 
-trio = TrioOutput(logger, LOG_LEVEL)
+trio = TripleOutput(logger, LOG_LEVEL)
 sys.stdout = trio
 sys.stderr = trio

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -96,7 +96,7 @@ buffer_handler = BufferHandler()
 buffer_handler.setLevel(LOG_LEVEL)
 buffer_handler.setFormatter(formatter)
 
-logger = logging.getLogger()
+logger = logging.getLogger("freescribe")
 logger.setLevel(LOG_LEVEL)
 logger.addHandler(console_handler)
 logger.addHandler(file_handler)

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -1,5 +1,68 @@
 import os
+import sys
+from collections import deque
+from logging.handlers import RotatingFileHandler
 import logging
+
+
+class DualOutput:
+    MAX_BUFFER_SIZE = 2500  # Maximum number of lines in the buffer
+    buffer = None
+
+    def __init__(self):
+        """
+        Initialize the dual output handler.
+
+        Creates a deque buffer with a max length and stores references to original stdout/stderr streams.
+        """
+        DualOutput.buffer = deque(maxlen=DualOutput.MAX_BUFFER_SIZE)  # Buffer with a fixed size
+        self.original_stdout = sys.stdout  # Save the original stdout
+        self.original_stderr = sys.stderr  # Save the original stderr
+
+    def write(self, message):
+        """
+        Write a message to the buffer, original stdout, and log file.
+
+        :param message: The message to be written
+        :type message: str
+        """
+        if not message.strip():
+            message = '\n'
+        DualOutput.buffer.append(message)
+
+    def flush(self):
+        """
+        Flush the original stdout to ensure output is written immediately.
+        """
+        if self.original_stdout is not None:
+            self.original_stdout.flush()
+
+    @staticmethod
+    def get_buffer_content():
+        """
+        Retrieve all content stored in the buffer.
+
+        :return: The complete buffer contents as a single string.
+        :rtype: str
+        """
+        return ''.join(DualOutput.buffer)
+
+
+# Create a stream wrapper for stdout and stderr
+class StreamToLogger:
+    def __init__(self, logger, level, dual):
+        self.logger = logger
+        self.level = level
+        self.dual = dual
+
+    def write(self, message):
+        if message.strip():  # Avoid logging empty lines
+            self.logger.log(self.level, message.strip())
+        self.dual.write(message)
+
+    def flush(self):
+        # Required for compatibility with sys.stdout/sys.stderr
+        self.dual.flush()
 
 
 # Configure logging
@@ -7,19 +70,27 @@ if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG
 else:
     LOG_LEVEL = logging.INFO
-LOG_FILE_NAME = "../freescribe.log"
+LOG_FILE_NAME = os.path.join(os.getcwd(), "freescribe.log")
 # 10 MB
 LOG_FILE_MAX_SIZE = 10 * 1024 * 1024
 # Keep up to 1 backup log files
 LOG_FILE_BACKUP_COUNT = 1
 
-logging.basicConfig(
-    level=LOG_LEVEL,
-    format='%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler(sys.stdout),
-        RotatingFileHandler(LOG_FILE_NAME, maxBytes=LOG_FILE_MAX_SIZE, backupCount=LOG_FILE_BACKUP_COUNT)
-    ]
-)
 
-logger = logging.getLogger(__name__)
+
+formatter = logging.Formatter('%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
+console_handler = logging.StreamHandler(sys.stdout)
+console_handler.setLevel(LOG_LEVEL)
+console_handler.setFormatter(formatter)
+file_handler = RotatingFileHandler(LOG_FILE_NAME, maxBytes=LOG_FILE_MAX_SIZE, backupCount=LOG_FILE_BACKUP_COUNT)
+file_handler.setLevel(LOG_LEVEL)
+file_handler.setFormatter(formatter)
+logger = logging.getLogger()
+logger.setLevel(LOG_LEVEL)
+logger.addHandler(console_handler)
+logger.addHandler(file_handler)
+
+
+dual = DualOutput()
+sys.stdout = StreamToLogger(logger, logging.INFO, dual)
+sys.stderr = StreamToLogger(logger, logging.ERROR, dual)

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -187,7 +187,7 @@ buffer_handler.setFormatter(formatter)
 # root logger settings
 logging.basicConfig(
     level=logging.DEBUG,
-    handlers=[console_handler, file_handler, buffer_handler],
+    handlers=[console_handler, buffer_handler],
     format=LOG_FORMAT
 )
 logger = logging.getLogger("freescribe")

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -116,7 +116,7 @@ LOG_FILE_NAME = get_resource_path("freescribe.log")
 LOG_FILE_MAX_SIZE = 10 * 1024 * 1024
 # Keep up to 1 backup log files
 LOG_FILE_BACKUP_COUNT = 1
-LOG_FORMAT = '[%(asctime)s] | %(levelname)s | %(threadName)s | %(name)s | [%(filename)s:%(lineno)d in %(funcName)s] | %(message)s'
+LOG_FORMAT = '[%(asctime)s] | %(levelname)s | %(name)s | %(threadName)s | [%(filename)s:%(lineno)d in %(funcName)s] | %(message)s'
 
 formatter = logging.Formatter(LOG_FORMAT)
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -75,7 +75,7 @@ class TripleOutput:
             - Buffer
             - Original stdout
         """
-        self.logger.log(level=self.level, message=msg)
+        self.logger.log(self.level, msg)
         self.buffer.append(msg)
         self.original_stdout.write(msg)
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -116,7 +116,7 @@ LOG_FILE_NAME = get_resource_path("freescribe.log")
 LOG_FILE_MAX_SIZE = 10 * 1024 * 1024
 # Keep up to 1 backup log files
 LOG_FILE_BACKUP_COUNT = 1
-LOG_FORMAT = '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s'
+LOG_FORMAT = '%(asctime)s - %(levelname)s - %(threadName)s - %(name)s - [%(filename)s:%(lineno)d in %(funcName)s] - %(message)s'
 
 formatter = logging.Formatter(LOG_FORMAT)
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -12,12 +12,16 @@ class SafeStreamHandler(logging.StreamHandler):
     
     This handler extends logging.StreamHandler to prevent errors when
     working with potentially closed streams.
+
+    :ivar stream: The output stream being used
+    :vartype stream: io.TextIOWrapper
     """
     def emit(self, record):
         """Emit a record if the stream is open.
         
         :param record: The log record to emit
         :type record: logging.LogRecord
+        :return: None
         """
         if self.stream and not self.stream.closed:
             super().emit(record)
@@ -26,25 +30,32 @@ class SafeStreamHandler(logging.StreamHandler):
         """Close the handler only if the stream is open.
         
         Prevents errors when closing already-closed streams.
+        
+        :return: None
         """
         if self.stream and not self.stream.closed:  # Only close if open
             super().close()
 
 
 class BufferHandler(logging.Handler):
-    """A custom logging handler that writes log messages to the TrioOutput buffer.
+    """A custom logging handler that writes log messages to the buffer.
     
-    This handler captures log records and writes them to an in-memory buffer
-    maintained by the TripleOutput class.
+    This handler captures log records and writes them to an in-memory buffer.
+
+    :cvar MAX_BUFFER_SIZE: Maximum number of lines in the buffer
+    :vartype MAX_BUFFER_SIZE: int
+    :cvar buffer: The deque buffer storing log messages
+    :vartype buffer: collections.deque
     """
     MAX_BUFFER_SIZE = 2500  # Maximum number of lines in the buffer
     buffer = deque(maxlen=MAX_BUFFER_SIZE)
 
     def emit(self, record):
-        """Emit a record by writing it to the TrioOutput buffer.
+        """Emit a record by writing it to the buffer.
 
         :param record: The log record to be written
         :type record: logging.LogRecord
+        :return: None
         :note: Any exceptions during emission are handled by the parent class's handleError method
         """
         try:
@@ -66,6 +77,12 @@ class BufferHandler(logging.Handler):
 
 
 class TripleOutput:
+    """Handles triple output to buffer, stdout/stderr, and log file.
+    
+    :ivar log_func: The logging function to use for output
+    :vartype log_func: callable
+    """
+    
     def __init__(self, log_func):
         """Initialize the triple output handler.
 
@@ -79,6 +96,7 @@ class TripleOutput:
 
         :param message: The message to be written
         :type message: str
+        :return: None
         :note: 
             - Empty messages are ignored
             - Multi-line messages are split and written line by line
@@ -98,6 +116,10 @@ class TripleOutput:
             out.write(err)
 
     def flush(self):
+        """Dummy flush method to satisfy stream interface requirements.
+        
+        :return: None
+        """
         pass
 
 

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -123,6 +123,10 @@ LOG_FORMAT = '%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(messag
 
 formatter = logging.Formatter(LOG_FORMAT)
 
+# When running a PyInstaller-built application with --windowed mode, there's no console,
+# so sys.stdout and sys.stderr are set to None.
+# Since Python's logging module tries to write to sys.stdout (or another stream handler),
+# it fails with AttributeError: 'NoneType' object has no attribute 'write'.
 if sys.stderr or sys.stdout:
     console_handler = SafeStreamHandler(sys.stderr or sys.stdout)
 else:

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -140,8 +140,8 @@ def addLoggingLevel(levelName, levelNum, methodName=None):
 
 # Define custom level
 DIAGNOSE_LEVEL = 99
-# logging.addLevelName(DIAGNOSE_LEVEL, "DIAG")
 addLoggingLevel("DIAG", DIAGNOSE_LEVEL)
+
 # Configure logging
 if os.environ.get("FREESCRIBE_DEBUG"):
     LOG_LEVEL = logging.DEBUG

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -135,6 +135,6 @@ logger.addHandler(console_handler)
 logger.addHandler(file_handler)
 logger.addHandler(buffer_handler)
 
-trio = TripleOutput(logger, LOG_LEVEL)
-sys.stdout = trio
-sys.stderr = trio
+triple = TripleOutput(logger, LOG_LEVEL)
+sys.stdout = triple
+sys.stderr = triple

--- a/src/FreeScribe.client/utils/log_config.py
+++ b/src/FreeScribe.client/utils/log_config.py
@@ -101,7 +101,7 @@ LOG_FILE_BACKUP_COUNT = 1
 
 formatter = logging.Formatter('%(asctime)s - %(threadName)s - %(name)s - %(levelname)s - %(message)s')
 
-console_handler = logging.StreamHandler()
+console_handler = logging.StreamHandler(sys.stdout)
 console_handler.setLevel(LOG_LEVEL)
 console_handler.setFormatter(formatter)
 

--- a/src/FreeScribe.client/utils/utils.py
+++ b/src/FreeScribe.client/utils/utils.py
@@ -1,6 +1,8 @@
 
 import ctypes
 from utils.file_utils import get_file_path
+from utils.log_config import logger
+
 # Define the mutex name and error code
 MUTEX_NAME = 'Global\\FreeScribe_Instance'
 ERROR_ALREADY_EXISTS = 183
@@ -51,6 +53,6 @@ def get_application_version():
             with open(get_file_path('__version__'), 'r') as file:
                 version_str = file.read().strip()
         except Exception as e:
-            print(f"Error loading version file ({type(e).__name__}). {e}")
+            logger.error(f"Error loading version file ({type(e).__name__}). {e}")
         finally:
             return version_str


### PR DESCRIPTION
all print -> log
new format

![image](https://github.com/user-attachments/assets/9344d583-eee2-4f11-94d1-f4c51bc3613d)
time | level | logger name | thread name | filename:lineno in funcion | message

file handler removed




## Summary by Sourcery

This pull request introduces a comprehensive logging system to the application. It replaces all print statements with logging calls, directing output to the console, a debug window, and a rotating log file. The log file has a size limit of 10MB and keeps 1 backup file.

New Features:
- Implements triple logging, directing output to the console, a debug window, and a rotating log file.
- The log file has a size limit of 10MB and keeps 1 backup file.

Enhancements:
- Replaces all `print` statements with calls to the logging module for more robust and configurable output.

Chores:
- Removes the custom `DualOutput` class and replaces it with a standard logging configuration.

## Summary by Sourcery

Implements a comprehensive logging system using the logging module. It replaces all print statements with logging calls, directing output to the console, a debug window, and a rotating log file. The log file has a size limit of 10MB and keeps 1 backup file.

New Features:
- Implements triple logging, directing output to the console, a debug window, and a rotating log file.
- The log file has a size limit of 10MB and keeps 1 backup file.

Enhancements:
- Replaces all `print` statements with calls to the logging module for more robust and configurable output.

Chores:
- Removes the custom `DualOutput` class and replaces it with a standard logging configuration.