### PR TITLE
fix(note-gen-loading-box): Fixed two boxes existing at once and fixed wording. (High Priority)

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1377,7 +1377,7 @@ def generate_note_thread(text: str):
     # The return value from the screen input thread
     screen_return = tk.BooleanVar()
 
-    loading_window = LoadingWindow(root, "Generating Note.", "Generating Note. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))
+    loading_window = LoadingWindow(root, "Screening Input Text", "Ensuring input is valid. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))
     
     # screen input in its own thread so we can cancel it
     screen_thread = threading.Thread(target=threaded_screen_input, args=(text, screen_return))
@@ -1393,6 +1393,7 @@ def generate_note_thread(text: str):
         if display_screening_popup() is False:
             return
     
+    loading_window.destroy()
     loading_window = LoadingWindow(root, "Generating Note.", "Generating Note. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))
 
 


### PR DESCRIPTION
## Summary by Sourcery

This pull request addresses a bug where two loading windows could appear at the same time during note generation. It also improves the user experience by clarifying the purpose of the initial loading window with updated wording.

Bug Fixes:
- Fixes an issue where two loading windows could appear simultaneously.

Enhancements:
- Updates the wording of the initial loading window to reflect its purpose of screening input text.