### PR TITLE
fix: unload local ai/stt model if using remote

### DIFF
--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -2,6 +2,7 @@ from llama_cpp import Llama
 import os
 from typing import Optional, Dict, Any
 import threading
+import logging
 from UI.LoadingWindow import LoadingWindow
 import tkinter.messagebox as messagebox
 from UI.SettingsConstant import SettingsKeys, DEFAULT_CONTEXT_WINDOW_SIZE
@@ -289,4 +290,4 @@ class ModelManager:
             ModelManager.local_model.model.close()
             del ModelManager.local_model
             ModelManager.local_model = None
-            
+        logging.debug(f"{ModelManager.local_model=}")

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -569,14 +569,17 @@ class SettingsWindow():
         reload_flag = False
         try:
             if new_use_local_llm:
-                if any([old_model != new_model,
-                        old_architecture != new_architecture,
-                        int(old_context_window) != int(new_context_window)]):
+                if any([
+                    old_use_local_llm != new_use_local_llm,
+                    old_model != new_model,
+                    old_architecture != new_architecture,
+                    int(old_context_window) != int(new_context_window)]
+                ):
                     reload_flag = True
             else:
                 unload_flag = True
         except:
-            logging.exception("Failed to load model")
+            logging.exception("Failed to determine reload/unload model")
         logging.debug(f"load_or_unload_model {unload_flag=}, {reload_flag=}")
         return unload_flag, reload_flag
 

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -578,7 +578,9 @@ class SettingsWindow():
                     reload_flag = True
             else:
                 unload_flag = True
-        except:
+        # in case context_window value is invalid
+        except (ValueError, TypeError) as e:
+            logging.error(str(e))
             logging.exception("Failed to determine reload/unload model")
         logging.debug(f"load_or_unload_model {unload_flag=}, {reload_flag=}")
         return unload_flag, reload_flag

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -22,6 +22,7 @@ import os
 import tkinter as tk
 from tkinter import messagebox
 import requests
+import logging
 
 from UI.SettingsConstant import SettingsKeys, Architectures, FeatureToggle, DEFAULT_CONTEXT_WINDOW_SIZE
 from utils.file_utils import get_resource_path, get_file_path
@@ -564,25 +565,20 @@ class SettingsWindow():
                  - reload_flag: True if new model should be loaded
         :rtype: tuple(bool, bool)
         """
-        # Check if old model and new model are different if they are reload and make sure new model is checked.
-        if old_model != new_model and new_use_local_llm == 1:
-            return True, True
-
-        # Load the model if check box is now selected
-        if old_use_local_llm == 0 and new_use_local_llm == 1:
-            return False, True
-
-        # Check if Local LLM was on and if turned off unload model.abs
-        if old_use_local_llm == 1 and new_use_local_llm == 0:
-            return True, False
-
-        if old_architecture != new_architecture and new_use_local_llm == 1:
-            return True, True
-
-        if int(old_context_window) != int(new_context_window) and new_use_local_llm == 1:
-            return True, True
-
-        return False, False
+        unload_flag = False
+        reload_flag = False
+        try:
+            if new_use_local_llm:
+                if any([old_model != new_model,
+                        old_architecture != new_architecture,
+                        int(old_context_window) != int(new_context_window)]):
+                    reload_flag = True
+            else:
+                unload_flag = True
+        except:
+            logging.exception("Failed to load model")
+        logging.debug(f"load_or_unload_model {unload_flag=}, {reload_flag=}")
+        return unload_flag, reload_flag
 
     def _create_settings_and_aiscribe_if_not_exist(self):
         """

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -20,6 +20,7 @@ Classes:
 """
 
 import json
+import logging
 import tkinter as tk
 from tkinter import ttk, messagebox
 import threading
@@ -682,10 +683,15 @@ class SettingsWindowUI:
         # send load event after the settings are saved
         if update_whisper_model_flag:
             self.main_window.root.event_generate("<<LoadSttModel>>")
+        # unload whisper model if switched to remote
+        if not self.settings.editable_settings[SettingsKeys.LOCAL_WHISPER.value]:
+            self.main_window.root.event_generate("<<UnloadSttModel>>")
         # unload / reload model after the settings are saved
         if local_model_unload_flag:
+            logging.debug(f"unloading ai model")
             ModelManager.unload_model()
         if local_model_reload_flag:
+            logging.debug(f"reloading ai model")
             ModelManager.start_model_threaded(self.settings, self.main_window.root)
 
         if self.settings.editable_settings["Use Docker Status Bar"] and self.main_window.docker_status_bar is None:

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -688,10 +688,10 @@ class SettingsWindowUI:
             self.main_window.root.event_generate("<<UnloadSttModel>>")
         # unload / reload model after the settings are saved
         if local_model_unload_flag:
-            logging.debug(f"unloading ai model")
+            logging.debug("unloading ai model")
             ModelManager.unload_model()
         if local_model_reload_flag:
-            logging.debug(f"reloading ai model")
+            logging.debug("reloading ai model")
             ModelManager.start_model_threaded(self.settings, self.main_window.root)
 
         if self.settings.editable_settings["Use Docker Status Bar"] and self.main_window.docker_status_bar is None:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1718,8 +1718,9 @@ def _load_stt_model_thread():
             window.enable_settings_menu()
             stt_loading_window.destroy()
             print("Closing STT loading window.")
+        logging.debug(f"STT model status after loading: {stt_local_model=}")
 
-def unload_stt_model():
+def unload_stt_model(event=None):
     """
     Unload the speech-to-text model from memory.
     
@@ -1735,6 +1736,7 @@ def unload_stt_model():
         print("STT model unloaded successfully.")
     else:
         print("STT model is already unloaded.")
+    logging.debug(f"STT model status after unloading: {stt_local_model=}")
 
 def get_selected_whisper_architecture():
     """
@@ -2014,6 +2016,7 @@ def await_models(timeout_length=60):
 root.after(100, await_models)
 
 root.bind("<<LoadSttModel>>", load_stt_model)
+root.bind("<<UnloadSttModel>>", unload_stt_model)
 
 root.mainloop()
 


### PR DESCRIPTION
## Summary by Sourcery

This PR unloads the local AI/STT model when switching to a remote model to free up resources.