### PR TITLE
fix: lift the max_tokens limit off when using local model

### DIFF
--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -87,7 +87,7 @@ class Model:
     def generate_response(
         self,
         prompt: str,
-        max_tokens: int = -1,
+        max_tokens: int | None = None,
         temperature: float = 0.1,
         top_p: float = 0.95,
         repeat_penalty: float = 1.1

--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -87,7 +87,7 @@ class Model:
     def generate_response(
         self,
         prompt: str,
-        max_tokens: int = 50,
+        max_tokens: int = -1,
         temperature: float = 0.1,
         top_p: float = 0.95,
         repeat_penalty: float = 1.1

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1160,7 +1160,6 @@ def send_text_to_localmodel(edited_text):
 
     return ModelManager.local_model.generate_response(
         edited_text,
-        max_tokens=int(app_settings.editable_settings["max_length"]),
         temperature=float(app_settings.editable_settings["temperature"]),
         top_p=float(app_settings.editable_settings["top_p"]),
         repeat_penalty=float(app_settings.editable_settings["rep_pen"]),


### PR DESCRIPTION
#424 #368

## Summary by Sourcery

Bug Fixes:
- Removes the `max_tokens` limit when using a local model, allowing the model to generate responses of any length.