### PR TITLE
fix(window-hang): Fixed wording and closed window when done. (Urgent)

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1370,8 +1370,7 @@ def generate_note_thread(text: str):
     # The return value from the screen input thread
     screen_return = tk.BooleanVar()
 
-    loading_window = LoadingWindow(root, "Generating Note.", "Generating Note. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))
-    
+    loading_window = LoadingWindow(root, "Screening Input Text", "Ensuring input is valid. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))    
     # screen input in its own thread so we can cancel it
     screen_thread = threading.Thread(target=threaded_screen_input, args=(text, screen_return))
     screen_thread.start()
@@ -1386,6 +1385,7 @@ def generate_note_thread(text: str):
         if display_screening_popup() is False:
             return
     
+    loading_window.destroy()
     loading_window = LoadingWindow(root, "Generating Note.", "Generating Note. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))
 
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fixes a window hang by ensuring the initial loading window is closed before creating the second loading window.