### PR TITLE
fix: ModelManager.local_model.model could be none

### DIFF
--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -286,7 +286,8 @@ class ModelManager:
         the application.
         """
         if ModelManager.local_model is not None:
-            ModelManager.local_model.model.close()
+            if ModelManager.local_model.model:
+                ModelManager.local_model.model.close()
             del ModelManager.local_model
             ModelManager.local_model = None
             

--- a/src/FreeScribe.client/Model.py
+++ b/src/FreeScribe.client/Model.py
@@ -286,7 +286,7 @@ class ModelManager:
         the application.
         """
         if ModelManager.local_model is not None:
-            if ModelManager.local_model.model:
+            if ModelManager.local_model.model is not None:
                 ModelManager.local_model.model.close()
             del ModelManager.local_model
             ModelManager.local_model = None


### PR DESCRIPTION
When this error occured
![image](https://github.com/user-attachments/assets/7b3e4990-544c-4edb-aace-b16c00b24ed8)

ModelManager.local_model.model could be None
```
Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\tkinter\__init__.py", line 1921, in __call__
    return self.func(*args)
  File "D:\projects\FreeScribe\src\FreeScribe.client\UI\SettingsWindowUI.py", line 687, in save_settings
    ModelManager.unload_model()
  File "D:\projects\FreeScribe\src\FreeScribe.client\Model.py", line 289, in unload_model
    ModelManager.local_model.model.close()
AttributeError: 'ModelStatus' object has no attribute 'model'
Exception in Tkinter callback
Traceback (most recent call last):
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\tkinter\__init__.py", line 1921, in __call__
    return self.func(*args)
  File "D:\projects\FreeScribe\src\FreeScribe.client\UI\SettingsWindowUI.py", line 687, in save_settings
    ModelManager.unload_model()
  File "D:\projects\FreeScribe\src\FreeScribe.client\Model.py", line 289, in unload_model
    ModelManager.local_model.model.close()
AttributeError: 'ModelStatus' object has no attribute 'model'

```

## Summary by Sourcery

Bug Fixes:
- Fixes a crash when unloading the model if it is None.