### PR TITLE
fix(toggle-mic-bar): fixed style issue with mic bar when toggling recording. (mac-dev)

### DIFF
--- a/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
+++ b/src/FreeScribe.client/UI/Widgets/MicrophoneTestFrame.py
@@ -363,18 +363,31 @@ class MicrophoneTestFrame:
             enabled (bool): If True, enable the microphone test state. If False, disable it.
 
         Notes:
-            - For `ttk.Frame` or `tk.Frame` segments, the original style is stored before applying 
-            the disabled style. This allows the original style to be restored when re-enabled.
-            - The `_frame_original_styles` dictionary is used to store the original styles of frames.
-
-        Example:
-            >>> self.set_mic_test_state(True)  # Enable microphone test state
-            >>> self.set_mic_test_state(False) # Disable microphone test state
+            - For macOS compatibility, we use a combination of 'state' for ttk widgets and direct
+            property changes for standard tk widgets
+            - For tk.Frame segments, we update background color and other properties directly
+            - The `_frame_original_styles` dictionary is used to store the original properties
         """
-        self.mic_dropdown.state(['!disabled' if enabled else 'disabled'])
-        self.status_label.state(['!disabled' if enabled else 'disabled'])         
-        for segment in self.segments: 
-            if isinstance(segment, (ttk.Frame, tk.Frame)):
+        # Handle the microphone dropdown (ttk widget)
+        if hasattr(self.mic_dropdown, 'state'):
+            self.mic_dropdown.state(['!disabled'] if enabled else ['disabled'])
+        else:
+            self.mic_dropdown.configure(state='normal' if enabled else 'disabled')
+
+        # Handle the status label
+        if hasattr(self.status_label, 'state'):
+            self.status_label.state(['!disabled'] if enabled else ['disabled'])
+        else:
+            self.status_label.configure(state='normal' if enabled else 'disabled')
+            
+        # Initialize the storage dictionary if it doesn't exist
+        if not hasattr(self, '_frame_original_styles'):
+            self._frame_original_styles = {}
+            
+        # Handle segments
+        for segment in self.segments:
+            if isinstance(segment, ttk.Frame):
+                # Handle ttk.Frame
                 if enabled:
                     # Restore original style if it exists
                     original_style = self._frame_original_styles.get(segment, '')
@@ -385,8 +398,35 @@ class MicrophoneTestFrame:
                     if segment not in self._frame_original_styles:
                         self._frame_original_styles[segment] = current_style
                     segment.configure(style='Disabled.TFrame')
+            elif isinstance(segment, tk.Frame):
+                # Handle tk.Frame differently since macOS can have issues with ttk styling
+                if enabled:
+                    # Restore original properties
+                    if segment in self._frame_original_styles:
+                        properties = self._frame_original_styles[segment]
+                        segment.configure(**properties)
+                else:
+                    # Store original properties
+                    properties = {
+                        'bg': segment.cget('bg'),
+                        'highlightbackground': segment.cget('highlightbackground') if 'highlightbackground' in segment.keys() else None,
+                        'highlightcolor': segment.cget('highlightcolor') if 'highlightcolor' in segment.keys() else None
+                    }
+                    self._frame_original_styles[segment] = {k: v for k, v in properties.items() if v is not None}
+                    
+                    # Apply disabled appearance
+                    segment.configure(bg=self.style_colours.get('inactive', '#cccccc'))
+                    if 'highlightbackground' in segment.keys():
+                        segment.configure(highlightbackground='#cccccc')
+                    if 'highlightcolor' in segment.keys():
+                        segment.configure(highlightcolor='#cccccc')
             else:
-                segment.state(['!disabled' if enabled else 'disabled'])  
+                # Handle other ttk widgets
+                if hasattr(segment, 'state'):
+                    segment.state(['!disabled'] if enabled else ['disabled'])
+                else:
+                    # Handle regular tk widgets
+                    segment.configure(state='normal' if enabled else 'disabled')
 
     def __del__(self):
         """


### PR DESCRIPTION
## Summary by Sourcery

Fixes a style issue with the microphone bar when toggling recording, specifically addressing compatibility issues on macOS. The fix ensures that both ttk and tk widgets are correctly disabled and styled when the microphone test state is changed.

Bug Fixes:
- Fixes the style of tk.Frame widgets when disabled on macOS, ensuring the background and highlight colors are correctly updated to reflect the disabled state.
- Fixes the state of regular tk widgets when disabled, ensuring they are correctly disabled.