### PR TITLE
disable setting button when recording

### DIFF
--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -225,7 +225,7 @@ class MainWindowUI:
             self.root.after_cancel(self.current_container_status_check_id)
             self.current_container_status_check_id = None
 
-    def toggle_menu_bar(self, enable: bool):
+    def toggle_menu_bar(self, enable: bool, is_recording: bool = False):
         """
         Enable or disable the menu bar.
 
@@ -234,6 +234,8 @@ class MainWindowUI:
         """
         if enable:
             self._create_menu_bar()
+            if is_recording:
+                self.disable_settings_menu()
         else:
             self._destroy_menu_bar()
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1493,7 +1493,7 @@ def set_full_view():
     
     
 
-    window.toggle_menu_bar(enable=True)
+    window.toggle_menu_bar(enable=True, is_recording=is_recording)
 
     # Reconfigure button styles and text
     mic_button.config(bg="red" if is_recording else DEFAULT_BUTTON_COLOUR,


### PR DESCRIPTION
### Issue
- #443 

### Changes
- Keep the setting button disabled, when going from minimized to maximized view while recording

## Summary by Sourcery

Disable the settings menu when transitioning from a minimized to a maximized view during recording.