### PR TITLE
add small delay in while loop to prevent high cpu usage

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -442,6 +442,10 @@ def record_audio():
                     current_chunk = []
                     silent_duration = 0
                     record_duration = 0
+            else:
+                # Add a small delay to prevent high CPU usage
+                time.sleep(0.01)
+
 
         # Send any remaining audio chunk when recording stops
         if current_chunk:


### PR DESCRIPTION
### Issue
- #445 

### Reason
- When, `is_paused` was true, entire code block was skipped resulting in empty infinite while loop, which lead to high CPU usage. Thus causing the application to lag.

### Fix
- Added small delay in while loop while `is_paused` is `true` to reduce unnecessary CPU consumption.

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where an empty infinite while loop caused high CPU usage when the application was paused.