### PR TITLE
reset silent warning duration on new recording

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -590,7 +590,7 @@ def save_audio():
         threaded_send_audio_to_server()
 
 def toggle_recording():
-    global is_recording, recording_thread, DEFAULT_BUTTON_COLOUR, audio_queue, current_view, REALTIME_TRANSCRIBE_THREAD_ID, frames
+    global is_recording, recording_thread, DEFAULT_BUTTON_COLOUR, audio_queue, current_view, REALTIME_TRANSCRIBE_THREAD_ID, frames, silent_warning_duration
 
     # Reset the cancel flags going into a fresh recording
     if not is_recording:
@@ -617,6 +617,7 @@ def toggle_recording():
 
         # reset frames before new recording so old data is not used
         frames = []
+        silent_warning_duration = 0
         recording_thread = threading.Thread(target=record_audio)
         recording_thread.start()
 


### PR DESCRIPTION
### Issue
- #446 

### Fix
- Reset `silent_warning_duration` on new recoding

## Summary by Sourcery

Resets the silent_warning_duration variable when a new recording starts to prevent false warnings.