### PR TITLE
Fix integer, boolean values in settings txt are saved as string and 0,1 (dev)

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath=src/FreeScribe.client

--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -25,6 +25,7 @@ class SettingsKeys(Enum):
     LLM_SERVER_API_KEY = "AI Server API Key"
     Enable_Word_Count_Validation = "Enable Word Count Validation"
     Enable_AI_Conversation_Validation = "Enable AI Conversation Validation"
+    BEST_OF = "Best of N (Experimental)"
 
 
 class Architectures(Enum):

--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -25,7 +25,7 @@ class SettingsKeys(Enum):
     LLM_SERVER_API_KEY = "AI Server API Key"
     Enable_Word_Count_Validation = "Enable Word Count Validation"
     Enable_AI_Conversation_Validation = "Enable AI Conversation Validation"
-    BEST_OF = "Best of N (Experimental)"
+    BEST_OF = "best_of"
 
 
 class Architectures(Enum):

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -23,6 +23,7 @@ import tkinter as tk
 from tkinter import messagebox
 import requests
 import logging
+from typing import List, Dict, Any, Union, Optional, Tuple
 
 from UI.SettingsConstant import SettingsKeys, Architectures, FeatureToggle, DEFAULT_CONTEXT_WINDOW_SIZE
 from utils.file_utils import get_resource_path, get_file_path
@@ -271,7 +272,7 @@ class SettingsWindow():
             self.scribe_template_values = ["Settings Template"]
             self.scribe_template_mapping["Settings Template"] = (self.AISCRIBE, self.AISCRIBE2)
 
-    def get_boolean_settings(self):
+    def get_boolean_settings(self) -> List[str]:
         """
         Returns a list of setting keys that have boolean values in the DEFAULT_SETTINGS_TABLE.
         
@@ -281,7 +282,7 @@ class SettingsWindow():
         return [key for key, value in self.DEFAULT_SETTINGS_TABLE.items() 
                 if isinstance(value, bool)]
 
-    def _get_integer_settings(self):
+    def _get_integer_settings(self) -> List[str]:
         """
         Returns a list of setting keys that have integer values in the DEFAULT_SETTINGS_TABLE.
         Excludes boolean values since bool is a subclass of int in Python.
@@ -292,7 +293,7 @@ class SettingsWindow():
         return [key for key, value in self.DEFAULT_SETTINGS_TABLE.items() 
                 if isinstance(value, int) and not isinstance(value, bool)]
 
-    def get_extended_integer_settings(self):
+    def get_extended_integer_settings(self) -> List[str]:
         """
         Returns an extended list of setting keys that should be treated as integers.
         
@@ -320,7 +321,9 @@ class SettingsWindow():
         boolean_settings = self.get_boolean_settings()
         return list(set(integer_settings) - set(boolean_settings))
 
-    def convert_setting_value(self, setting, value, boolean_settings=None, integer_settings=None):
+    def convert_setting_value(self, setting: str, value: Any, 
+                             boolean_settings: Optional[List[str]] = None, 
+                             integer_settings: Optional[List[str]] = None) -> Any:
         """
         Convert a setting value to the appropriate type based on the setting name.
         

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -282,13 +282,9 @@ class SettingsWindow():
 
     def get_integer_settings(self) -> List[str]:
         """
-        Returns an extended list of setting keys that should be treated as integers.
-        
-        This includes settings from DEFAULT_SETTINGS_TABLE that have integer values,
-        as well as known integer settings that might not be in DEFAULT_SETTINGS_TABLE.
-        It also ensures there's no overlap with boolean settings.
-        
-        :returns: Extended list of setting keys that should be treated as integers
+        Returns a list of setting keys that have integer values in the DEFAULT_SETTINGS_TABLE.
+
+        :returns: List of setting keys with integer values
         :rtype: list
         """
         # Get base integer settings from DEFAULT_SETTINGS_TABLE

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -796,18 +796,9 @@ class SettingsWindowUI:
         tk.Label(frame, text=label).grid(row=row_idx, column=0, padx=0, pady=5, sticky="w")
         value = self.settings.editable_settings[setting_name]
         
-        # Check if this is an integer setting
-        integer_settings = []
-        if hasattr(self.settings, 'get_extended_integer_settings'):
-            integer_settings = self.settings.get_extended_integer_settings()
-        
-        # Ensure value is displayed correctly based on its type
-        if setting_name in integer_settings and not isinstance(value, int):
-            try:
-                value = int(value)
-            except (ValueError, TypeError):
-                # If conversion fails, keep the original value
-                logging.warning(f"Warning: Could not convert {setting_name} value to integer")
+        # Convert the value to the appropriate type using the helper method
+        if hasattr(self.settings, 'convert_setting_value'):
+            value = self.settings.convert_setting_value(setting_name, value)
         
         entry = tk.Entry(frame, width=LONG_ENTRY_WIDTH)
         entry.insert(0, str(value))

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -460,7 +460,7 @@ class SettingsWindowUI:
                 continue
 
             value = self.settings.editable_settings[setting_name]
-            if value in [True, False]:
+            if type(value) is bool:
                 self.widgets[setting_name] = self._create_checkbox(frame, setting_name, setting_name, row)
             else:
                 self.widgets[setting_name] = self._create_entry(frame, setting_name, setting_name, row)
@@ -772,7 +772,9 @@ class SettingsWindowUI:
             row_idx (int): The row index at which to place the checkbox.
         """
         tk.Label(frame, text=label).grid(row=row_idx, column=0, padx=0, pady=5, sticky="w")
-        value = tk.IntVar(value=int(self.settings.editable_settings[setting_name]))
+        # Convert to bool to ensure proper type
+        current_value = bool(self.settings.editable_settings[setting_name])
+        value = tk.BooleanVar(value=current_value)
         checkbox = tk.Checkbutton(frame, variable=value)
         checkbox.grid(row=row_idx, column=1, padx=0, pady=5, sticky="w")
         self.settings.editable_settings_entries[setting_name] = value

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -460,7 +460,8 @@ class SettingsWindowUI:
                 row += 1
                 continue
 
-            boolean_settings = self.settings.get_boolean_settings()
+            boolean_settings = [key for key, type_value in self.settings.setting_types.items() 
+                            if type_value == bool]
             if setting_name in boolean_settings:
                 self.widgets[setting_name] = self._create_checkbox(frame, setting_name, setting_name, row)
             else:

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -798,13 +798,8 @@ class SettingsWindowUI:
         
         # Check if this is an integer setting
         integer_settings = []
-        if hasattr(self.settings, 'get_integer_settings'):
-            integer_settings = self.settings.get_integer_settings()
-            # Add known integer settings that might not be in DEFAULT_SETTINGS_TABLE
-            integer_settings.extend(["max_context_length", "max_length", "rep_pen_range", "top_k", 
-                                   SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value])
-            # Remove duplicates
-            integer_settings = list(set(integer_settings))
+        if hasattr(self.settings, 'get_extended_integer_settings'):
+            integer_settings = self.settings.get_extended_integer_settings()
         
         # Ensure value is displayed correctly based on its type
         if setting_name in integer_settings and not isinstance(value, int):

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -256,6 +256,38 @@ def test_string_to_integer_conversion(settings, test_dir, integer_setting, setti
         f"Setting {integer_setting} value was not converted correctly"
 
 
+def test_invalid_string_to_integer_conversion(settings, integer_setting):
+    """Test that an invalid string for integer conversion is handled gracefully."""
+    # Backup the original value so that tests remain isolated
+    original_value = settings.editable_settings.get(integer_setting, None)
+    
+    try:
+        # Set an invalid string value that cannot be converted to an integer
+        invalid_value = "invalid_int"
+        settings.editable_settings[integer_setting] = invalid_value
+        
+        # Get the boolean and integer settings lists
+        boolean_settings = settings.get_boolean_settings()
+        integer_settings = settings.get_extended_integer_settings()
+        
+        # Call the convert_setting_value method directly
+        result = settings.convert_setting_value(
+            integer_setting, invalid_value, boolean_settings, integer_settings
+        )
+        
+        # The method should return the original value when conversion fails
+        assert result == invalid_value, \
+            "Invalid string should be returned as-is when conversion to integer fails"
+        
+        # The method should not modify the original value in editable_settings
+        assert settings.editable_settings[integer_setting] == invalid_value, \
+            "Original invalid value in editable_settings should not be modified"
+    finally:
+        # Restore the original value after the test
+        if original_value is not None:
+            settings.editable_settings[integer_setting] = original_value
+
+
 def test_invalid_json_settings(settings, test_dir, settings_file_path):
     """Test how settings handle an invalid JSON file."""
     # Create an invalid JSON content

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -32,14 +32,30 @@ def write_settings_file(test_dir, content, filename='settings.txt'):
     Write content to a settings file in the test directory.
     
     :param test_dir: The test directory
-    :param content: The content to write (string)
+    :param content: The content to write (string or dict)
     :param filename: The filename to use, defaults to 'settings.txt'
     :return: The path to the created file
     """
     path = os.path.join(test_dir, filename)
     with open(path, 'w') as f:
-        f.write(content)
+        if isinstance(content, dict):
+            json.dump(content, f)
+        else:
+            f.write(content)
     return path
+
+
+# Helper function to verify settings remain unchanged
+def verify_settings_unchanged(original_settings, current_settings):
+    """
+    Verify that settings remain unchanged.
+    
+    :param original_settings: The original settings dictionary
+    :param current_settings: The current settings dictionary
+    """
+    for key, value in original_settings.items():
+        assert current_settings[key] == value, \
+            f"Setting {key} was changed unexpectedly"
 
 
 @pytest.fixture
@@ -67,224 +83,187 @@ def settings(test_dir):
         yield settings_instance
 
 
-def test_boolean_settings_save_load(settings, test_dir):
-    """Test that boolean settings are saved and loaded correctly."""
-    # Get boolean settings
+@pytest.fixture
+def boolean_setting(settings):
+    """Get a boolean setting for testing."""
     boolean_settings = settings.get_boolean_settings()
-    
-    # Ensure we have at least one boolean setting to test
-    assert len(boolean_settings) > 0, "No boolean settings found to test"
-    
-    # Select a boolean setting to test
-    test_setting = boolean_settings[0]
-    
+    if not boolean_settings:
+        pytest.skip("No boolean settings found to test")
+    return boolean_settings[0]
+
+
+@pytest.fixture
+def integer_setting(settings):
+    """Get an integer setting for testing."""
+    integer_settings = get_extended_integer_settings(settings)
+    if not integer_settings:
+        pytest.skip("No integer settings found to test")
+    return integer_settings[0]
+
+
+@pytest.fixture
+def settings_file_path(test_dir):
+    """Get the path to the settings file."""
+    return os.path.join(test_dir, 'settings.txt')
+
+
+def test_boolean_settings_save_load(settings, test_dir, boolean_setting, settings_file_path):
+    """Test that boolean settings are saved and loaded correctly."""
     # Set the value to True
-    settings.editable_settings[test_setting] = True
+    settings.editable_settings[boolean_setting] = True
     
     # Save settings
     settings.save_settings_to_file()
     
     # Verify the settings file exists
-    settings_file = os.path.join(test_dir, 'settings.txt')
-    assert os.path.exists(settings_file), "Settings file was not created"
+    assert os.path.exists(settings_file_path), "Settings file was not created"
     
     # Read the file directly to verify the value was saved as a boolean
-    with open(settings_file, 'r') as f:
+    with open(settings_file_path, 'r') as f:
         saved_settings = json.load(f)
     
     # Check that the value is saved as a boolean (true), not as a string or integer
-    assert isinstance(saved_settings['editable_settings'][test_setting], bool), \
-        f"Setting {test_setting} was not saved as a boolean"
-    assert saved_settings['editable_settings'][test_setting] is True, \
-        f"Setting {test_setting} value was not saved correctly"
+    assert isinstance(saved_settings['editable_settings'][boolean_setting], bool), \
+        f"Setting {boolean_setting} was not saved as a boolean"
+    assert saved_settings['editable_settings'][boolean_setting] is True, \
+        f"Setting {boolean_setting} value was not saved correctly"
     
     # Change the value in memory
-    settings.editable_settings[test_setting] = False
+    settings.editable_settings[boolean_setting] = False
     
     # Load settings
     settings.load_settings_from_file()
     
     # Verify the value was loaded correctly as a boolean
-    assert isinstance(settings.editable_settings[test_setting], bool), \
-        f"Setting {test_setting} was not loaded as a boolean"
-    assert settings.editable_settings[test_setting] is True, \
-        f"Setting {test_setting} value was not loaded correctly"
+    assert isinstance(settings.editable_settings[boolean_setting], bool), \
+        f"Setting {boolean_setting} was not loaded as a boolean"
+    assert settings.editable_settings[boolean_setting] is True, \
+        f"Setting {boolean_setting} value was not loaded correctly"
 
 
-def test_integer_settings_save_load(settings, test_dir):
+def test_integer_settings_save_load(settings, test_dir, integer_setting, settings_file_path):
     """Test that integer settings are saved and loaded correctly."""
-    # Get extended integer settings
-    integer_settings = get_extended_integer_settings(settings)
-    
-    # Ensure we have at least one integer setting to test
-    assert len(integer_settings) > 0, "No integer settings found to test"
-    
-    # Select an integer setting to test
-    test_setting = integer_settings[0]
-    
     # Set the value to a test integer
     test_value = 42
-    settings.editable_settings[test_setting] = test_value
+    settings.editable_settings[integer_setting] = test_value
     
     # Save settings
     settings.save_settings_to_file()
     
     # Verify the settings file exists
-    settings_file = os.path.join(test_dir, 'settings.txt')
-    assert os.path.exists(settings_file), "Settings file was not created"
+    assert os.path.exists(settings_file_path), "Settings file was not created"
     
     # Read the file directly to verify the value was saved as an integer
-    with open(settings_file, 'r') as f:
+    with open(settings_file_path, 'r') as f:
         saved_settings = json.load(f)
     
     # Check that the value is saved as an integer, not as a string
-    assert isinstance(saved_settings['editable_settings'][test_setting], int), \
-        f"Setting {test_setting} was not saved as an integer"
-    assert saved_settings['editable_settings'][test_setting] == test_value, \
-        f"Setting {test_setting} value was not saved correctly"
+    assert isinstance(saved_settings['editable_settings'][integer_setting], int), \
+        f"Setting {integer_setting} was not saved as an integer"
+    assert saved_settings['editable_settings'][integer_setting] == test_value, \
+        f"Setting {integer_setting} value was not saved correctly"
     
     # Change the value in memory
-    settings.editable_settings[test_setting] = 0
+    settings.editable_settings[integer_setting] = 0
     
     # Load settings
     settings.load_settings_from_file()
     
     # Verify the value was loaded correctly as an integer
-    assert isinstance(settings.editable_settings[test_setting], int), \
-        f"Setting {test_setting} was not loaded as an integer"
-    assert settings.editable_settings[test_setting] == test_value, \
-        f"Setting {test_setting} value was not loaded correctly"
+    assert isinstance(settings.editable_settings[integer_setting], int), \
+        f"Setting {integer_setting} was not loaded as an integer"
+    assert settings.editable_settings[integer_setting] == test_value, \
+        f"Setting {integer_setting} value was not loaded correctly"
 
 
-def test_mixed_settings_save_load(settings, test_dir):
+def test_mixed_settings_save_load(settings, test_dir, boolean_setting, integer_setting):
     """Test that a mix of boolean and integer settings are saved and loaded correctly."""
-    # Get boolean and integer settings
-    boolean_settings = settings.get_boolean_settings()
-    integer_settings = get_extended_integer_settings(settings)
-    
-    # Ensure we have at least one of each type to test
-    if not boolean_settings:
-        pytest.skip("No boolean settings found to test")
-    if not integer_settings:
-        pytest.skip("No integer settings found to test")
-    
-    # Select one setting of each type to test
-    bool_setting = boolean_settings[0]
-    int_setting = integer_settings[0]
-    
     # Set test values
     bool_value = True
     int_value = 42
-    settings.editable_settings[bool_setting] = bool_value
-    settings.editable_settings[int_setting] = int_value
+    settings.editable_settings[boolean_setting] = bool_value
+    settings.editable_settings[integer_setting] = int_value
     
     # Save settings
     settings.save_settings_to_file()
     
     # Change the values in memory
-    settings.editable_settings[bool_setting] = False
-    settings.editable_settings[int_setting] = 0
+    settings.editable_settings[boolean_setting] = False
+    settings.editable_settings[integer_setting] = 0
     
     # Load settings
     settings.load_settings_from_file()
     
     # Verify both values were loaded correctly with the right types
-    assert isinstance(settings.editable_settings[bool_setting], bool), \
-        f"Setting {bool_setting} was not loaded as a boolean"
-    assert settings.editable_settings[bool_setting] == bool_value, \
-        f"Setting {bool_setting} value was not loaded correctly"
+    assert isinstance(settings.editable_settings[boolean_setting], bool), \
+        f"Setting {boolean_setting} was not loaded as a boolean"
+    assert settings.editable_settings[boolean_setting] == bool_value, \
+        f"Setting {boolean_setting} value was not loaded correctly"
     
-    assert isinstance(settings.editable_settings[int_setting], int), \
-        f"Setting {int_setting} was not loaded as an integer"
-    assert settings.editable_settings[int_setting] == int_value, \
-        f"Setting {int_setting} value was not loaded correctly"
+    assert isinstance(settings.editable_settings[integer_setting], int), \
+        f"Setting {integer_setting} was not loaded as an integer"
+    assert settings.editable_settings[integer_setting] == int_value, \
+        f"Setting {integer_setting} value was not loaded correctly"
 
 
-def test_string_to_boolean_conversion(settings, test_dir):
-    """Test that string representations of booleans are converted correctly."""
-    # Get boolean settings
-    boolean_settings = settings.get_boolean_settings()
-    
-    # Ensure we have at least one boolean setting to test
-    if not boolean_settings:
-        pytest.skip("No boolean settings found to test")
-    
-    # Select a boolean setting to test
-    test_setting = boolean_settings[0]
-    
-    # First, make sure the setting is recognized as a boolean in the default settings
-    # by setting it to True and saving it
-    settings.editable_settings[test_setting] = True
-    settings.save_settings_to_file()
-    
-    # Now create a settings file with a string representation of a boolean
+def test_integer_to_boolean_conversion(settings, test_dir, boolean_setting, settings_file_path):
+    """Test that integer representations of booleans (0/1) are converted correctly."""
+    # Create a settings file with an integer representation of a boolean
     settings_data = {
         "openai_api_key": "test_key",
         "editable_settings": {
-            test_setting: "1"  # String representation of True
+            boolean_setting: 1  # Integer representation of True
         },
         "app_version": "1.0.0"
     }
     
-    settings_file = os.path.join(test_dir, 'settings.txt')
-    with open(settings_file, 'w') as f:
+    # Write the settings file
+    with open(settings_file_path, 'w') as f:
         json.dump(settings_data, f)
     
     # Load settings
     settings.load_settings_from_file()
     
-    # Verify the value was converted to a boolean or at least has boolean-like behavior
-    # Some implementations might keep it as a string but treat it as a boolean in logic
-    value = settings.editable_settings[test_setting]
-    
-    # Test if the value behaves like True in a boolean context
-    assert bool(value), f"Setting {test_setting} value does not behave like True"
-    
-    # If it's not a boolean, print a warning but don't fail the test
-    if not isinstance(value, bool):
-        print(f"Warning: Setting {test_setting} was loaded as {type(value).__name__} instead of bool")
+    # Verify the value was converted to a boolean
+    assert isinstance(settings.editable_settings[boolean_setting], bool), \
+        f"Setting {boolean_setting} was not converted to a boolean"
+    assert settings.editable_settings[boolean_setting] is True, \
+        f"Setting {boolean_setting} value was not converted correctly"
 
 
-def test_string_to_integer_conversion(settings, test_dir):
+def test_string_to_integer_conversion(settings, test_dir, integer_setting, settings_file_path):
     """Test that string representations of integers are converted correctly."""
-    # Get extended integer settings
-    integer_settings = get_extended_integer_settings(settings)
-    
-    # Ensure we have at least one integer setting to test
-    if not integer_settings:
-        pytest.skip("No integer settings found to test")
-    
-    # Select an integer setting to test
-    test_setting = integer_settings[0]
-    
     # Create a settings file with a string representation of an integer
     settings_data = {
         "openai_api_key": "test_key",
         "editable_settings": {
-            test_setting: "42"  # String representation of integer
+            integer_setting: "42"  # String representation of integer
         },
         "app_version": "1.0.0"
     }
     
-    settings_file = os.path.join(test_dir, 'settings.txt')
-    with open(settings_file, 'w') as f:
+    # Write the settings file
+    with open(settings_file_path, 'w') as f:
         json.dump(settings_data, f)
     
     # Load settings
     settings.load_settings_from_file()
     
     # Verify the value was converted to an integer
-    assert isinstance(settings.editable_settings[test_setting], int), \
-        f"Setting {test_setting} was not converted to an integer"
-    assert settings.editable_settings[test_setting] == 42, \
-        f"Setting {test_setting} value was not converted correctly"
+    assert isinstance(settings.editable_settings[integer_setting], int), \
+        f"Setting {integer_setting} was not converted to an integer"
+    assert settings.editable_settings[integer_setting] == 42, \
+        f"Setting {integer_setting} value was not converted correctly"
 
 
-def test_invalid_json_settings(settings, test_dir):
+def test_invalid_json_settings(settings, test_dir, settings_file_path):
     """Test how settings handle an invalid JSON file."""
     # Create an invalid JSON content
     invalid_json = "{invalid: 'json', missing quotes}"  # intentionally invalid JSON
-    write_settings_file(test_dir, invalid_json)
+    
+    # Write the invalid JSON to the settings file
+    with open(settings_file_path, 'w') as f:
+        f.write(invalid_json)
     
     # Save the original settings to compare later
     original_settings = settings.editable_settings.copy()
@@ -293,16 +272,17 @@ def test_invalid_json_settings(settings, test_dir):
     settings.load_settings_from_file()
     
     # Verify that the settings remain unchanged when loading invalid JSON
-    for key, value in original_settings.items():
-        assert settings.editable_settings[key] == value, \
-            f"Setting {key} was changed after loading invalid JSON"
+    verify_settings_unchanged(original_settings, settings.editable_settings)
 
 
-def test_settings_missing_keys(settings, test_dir):
+def test_settings_missing_keys(settings, test_dir, settings_file_path):
     """Test how settings behave when required keys are missing."""
     # Create a settings file missing required keys
     incomplete_settings = '{"openai_api_key": "test_key"}'  # Missing editable_settings
-    write_settings_file(test_dir, incomplete_settings)
+    
+    # Write the incomplete settings to the settings file
+    with open(settings_file_path, 'w') as f:
+        f.write(incomplete_settings)
     
     # Save the original settings to compare later
     original_settings = settings.editable_settings.copy()
@@ -311,40 +291,32 @@ def test_settings_missing_keys(settings, test_dir):
     settings.load_settings_from_file()
     
     # Verify that the settings remain unchanged when loading incomplete settings
-    for key, value in original_settings.items():
-        assert settings.editable_settings[key] == value, \
-            f"Setting {key} was changed after loading settings with missing keys"
+    verify_settings_unchanged(original_settings, settings.editable_settings)
 
 
-def test_settings_extra_data(settings, test_dir):
+def test_settings_extra_data(settings, test_dir, boolean_setting, settings_file_path):
     """Test how settings behave when the settings file contains extra unexpected data."""
-    # Get a boolean setting to test
-    boolean_settings = settings.get_boolean_settings()
-    if not boolean_settings:
-        pytest.skip("No boolean settings found to test")
-    test_setting = boolean_settings[0]
-    
     # Create a settings file with extra keys not defined in the schema
     extra_data_settings = {
         "openai_api_key": "test_key",
         "editable_settings": {
-            test_setting: True,
+            boolean_setting: True,
             "unexpectedKey": "unexpectedValue"
         },
         "app_version": "1.0.0",
         "extraTopLevelKey": "extraTopLevelValue"
     }
     
-    settings_file = os.path.join(test_dir, 'settings.txt')
-    with open(settings_file, 'w') as f:
+    # Write the settings with extra data to the settings file
+    with open(settings_file_path, 'w') as f:
         json.dump(extra_data_settings, f)
     
     # Load settings - should not raise an exception
     settings.load_settings_from_file()
     
     # Verify that the known setting was loaded correctly
-    assert settings.editable_settings[test_setting] is True, \
-        f"Setting {test_setting} was not loaded correctly from settings with extra data"
+    assert settings.editable_settings[boolean_setting] is True, \
+        f"Setting {boolean_setting} was not loaded correctly from settings with extra data"
     
     # Verify that the unexpected key was not added to editable_settings
     assert "unexpectedKey" not in settings.editable_settings, \

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -86,17 +86,9 @@ def boolean_setting():
     """Get a specific boolean setting for testing."""
     # Use a known boolean setting from DEFAULT_SETTINGS_TABLE
     return "use_story"  # This is a known boolean setting
-def boolean_setting():
-    """Get a specific boolean setting for testing."""
-    # Use a known boolean setting from DEFAULT_SETTINGS_TABLE
-    return "use_story"  # This is a known boolean setting
 
 
 @pytest.fixture
-def integer_setting():
-    """Get a specific integer setting for testing."""
-    # Use a known integer setting from DEFAULT_SETTINGS_TABLE
-    return "max_context_length"  # This is a known integer setting
 def integer_setting():
     """Get a specific integer setting for testing."""
     # Use a known integer setting from DEFAULT_SETTINGS_TABLE

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -12,19 +12,18 @@ from UI.SettingsConstant import SettingsKeys
 
 
 # Helper function to get extended integer settings
-def get_extended_integer_settings(settings_instance: SettingsWindow) -> List[str]:
+def get_integer_settings(settings_instance: SettingsWindow) -> List[str]:
     """
-    Get integer settings extended with known integer settings.
+    Get integer settings.
     
-    This helper function gets the base integer settings from the settings instance
-    and extends them with known integer settings that might not be in DEFAULT_SETTINGS_TABLE.
-    It also ensures there's no overlap with boolean settings.
+    This helper function gets the integer settings from the settings instance's setting_types dictionary.
     
     :param settings_instance: The settings instance
     :return: List of integer setting keys
     """
-    # Use the get_extended_integer_settings method directly
-    return settings_instance.get_integer_settings()
+    # Get integer settings from setting_types dictionary
+    return [key for key, type_value in settings_instance.setting_types.items() 
+            if type_value == int]
 
 
 # Helper function to write a settings file with custom content
@@ -87,7 +86,8 @@ def settings(test_dir):
 @pytest.fixture
 def boolean_setting(settings):
     """Get a boolean setting for testing."""
-    boolean_settings = settings.get_boolean_settings()
+    boolean_settings = [key for key, type_value in settings.setting_types.items() 
+                        if type_value == bool]
     if not boolean_settings:
         pytest.skip("No boolean settings found to test")
     return boolean_settings[0]
@@ -96,7 +96,7 @@ def boolean_setting(settings):
 @pytest.fixture
 def integer_setting(settings):
     """Get an integer setting for testing."""
-    integer_settings = get_extended_integer_settings(settings)
+    integer_settings = get_integer_settings(settings)
     if not integer_settings:
         pytest.skip("No integer settings found to test")
     return integer_settings[0]
@@ -267,13 +267,9 @@ def test_invalid_string_to_integer_conversion(settings, integer_setting):
         invalid_value = "invalid_int"
         settings.editable_settings[integer_setting] = invalid_value
         
-        # Get the boolean and integer settings lists
-        boolean_settings = settings.get_boolean_settings()
-        integer_settings = settings.get_integer_settings()
-        
         # Call the convert_setting_value method directly
         result = settings.convert_setting_value(
-            integer_setting, invalid_value, boolean_settings, integer_settings
+            integer_setting, invalid_value
         )
         
         # The method should return the original value when conversion fails

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,6 +3,7 @@ import json
 import pytest
 import tempfile
 import shutil
+from typing import List, Dict, Any, Union, Optional
 from unittest.mock import patch, MagicMock
 
 # Import the SettingsWindow class with the correct paths
@@ -11,7 +12,7 @@ from UI.SettingsConstant import SettingsKeys
 
 
 # Helper function to get extended integer settings
-def get_extended_integer_settings(settings_instance):
+def get_extended_integer_settings(settings_instance: SettingsWindow) -> List[str]:
     """
     Get integer settings extended with known integer settings.
     
@@ -27,7 +28,7 @@ def get_extended_integer_settings(settings_instance):
 
 
 # Helper function to write a settings file with custom content
-def write_settings_file(test_dir, content, filename='settings.txt'):
+def write_settings_file(test_dir: str, content: Union[str, Dict[str, Any]], filename: str = 'settings.txt') -> str:
     """
     Write content to a settings file in the test directory.
     
@@ -46,7 +47,7 @@ def write_settings_file(test_dir, content, filename='settings.txt'):
 
 
 # Helper function to verify settings remain unchanged
-def verify_settings_unchanged(original_settings, current_settings):
+def verify_settings_unchanged(original_settings: Dict[str, Any], current_settings: Dict[str, Any]) -> None:
     """
     Verify that settings remain unchanged.
     

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,7 +24,7 @@ def get_extended_integer_settings(settings_instance: SettingsWindow) -> List[str
     :return: List of integer setting keys
     """
     # Use the get_extended_integer_settings method directly
-    return settings_instance.get_extended_integer_settings()
+    return settings_instance.get_integer_settings()
 
 
 # Helper function to write a settings file with custom content
@@ -269,7 +269,7 @@ def test_invalid_string_to_integer_conversion(settings, integer_setting):
         
         # Get the boolean and integer settings lists
         boolean_settings = settings.get_boolean_settings()
-        integer_settings = settings.get_extended_integer_settings()
+        integer_settings = settings.get_integer_settings()
         
         # Call the convert_setting_value method directly
         result = settings.convert_setting_value(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,6 +10,26 @@ from UI.SettingsWindow import SettingsWindow
 from UI.SettingsConstant import SettingsKeys
 
 
+# Helper function to get extended integer settings
+def get_extended_integer_settings(settings_instance):
+    """
+    Get integer settings extended with known integer settings.
+    
+    This helper function gets the base integer settings from the settings instance
+    and extends them with known integer settings that might not be in DEFAULT_SETTINGS_TABLE.
+    It also ensures there's no overlap with boolean settings.
+    
+    :param settings_instance: The settings instance
+    :return: List of integer setting keys
+    """
+    # Get base integer settings
+    integer_settings = settings_instance.get_extended_integer_settings()
+    
+    # Remove duplicates and ensure no overlap with boolean settings
+    boolean_settings = settings_instance.get_boolean_settings()
+    return list(set(integer_settings) - set(boolean_settings))
+
+
 @pytest.fixture
 def test_dir():
     """Create a temporary directory for test files."""
@@ -81,12 +101,8 @@ def test_boolean_settings_save_load(settings, test_dir):
 
 def test_integer_settings_save_load(settings, test_dir):
     """Test that integer settings are saved and loaded correctly."""
-    # Get integer settings
-    integer_settings = settings.get_integer_settings()
-    
-    # Add a known integer setting if the list is empty
-    if not integer_settings:
-        integer_settings = [SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value]
+    # Get extended integer settings
+    integer_settings = get_extended_integer_settings(settings)
     
     # Ensure we have at least one integer setting to test
     assert len(integer_settings) > 0, "No integer settings found to test"
@@ -132,13 +148,13 @@ def test_mixed_settings_save_load(settings, test_dir):
     """Test that a mix of boolean and integer settings are saved and loaded correctly."""
     # Get boolean and integer settings
     boolean_settings = settings.get_boolean_settings()
-    integer_settings = settings.get_integer_settings()
+    integer_settings = get_extended_integer_settings(settings)
     
     # Ensure we have at least one of each type to test
     if not boolean_settings:
         pytest.skip("No boolean settings found to test")
     if not integer_settings:
-        integer_settings = [SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value]
+        pytest.skip("No integer settings found to test")
     
     # Select one setting of each type to test
     bool_setting = boolean_settings[0]
@@ -219,12 +235,12 @@ def test_string_to_boolean_conversion(settings, test_dir):
 
 def test_string_to_integer_conversion(settings, test_dir):
     """Test that string representations of integers are converted correctly."""
-    # Get integer settings
-    integer_settings = settings.get_integer_settings()
+    # Get extended integer settings
+    integer_settings = get_extended_integer_settings(settings)
     
-    # Add a known integer setting if the list is empty
+    # Ensure we have at least one integer setting to test
     if not integer_settings:
-        integer_settings = [SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value]
+        pytest.skip("No integer settings found to test")
     
     # Select an integer setting to test
     test_setting = integer_settings[0]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,252 @@
+import os
+import json
+import pytest
+import tempfile
+import shutil
+from unittest.mock import patch, MagicMock
+
+# Import the SettingsWindow class with the correct paths
+from UI.SettingsWindow import SettingsWindow
+from UI.SettingsConstant import SettingsKeys
+
+
+@pytest.fixture
+def test_dir():
+    """Create a temporary directory for test files."""
+    temp_dir = tempfile.mkdtemp()
+    yield temp_dir
+    # Cleanup after test
+    shutil.rmtree(temp_dir)
+
+
+@pytest.fixture
+def settings(test_dir):
+    """Create a settings instance with mocked resource path."""
+    # Patch the get_resource_path function to use our test directory
+    with patch('UI.SettingsWindow.get_resource_path') as mock_get_resource_path:
+        mock_get_resource_path.side_effect = lambda path: os.path.join(test_dir, path)
+        
+        # Create a settings instance
+        settings_instance = SettingsWindow()
+        
+        # Mock the main_window attribute
+        settings_instance.main_window = None
+        
+        yield settings_instance
+
+
+def test_boolean_settings_save_load(settings, test_dir):
+    """Test that boolean settings are saved and loaded correctly."""
+    # Get boolean settings
+    boolean_settings = settings.get_boolean_settings()
+    
+    # Ensure we have at least one boolean setting to test
+    assert len(boolean_settings) > 0, "No boolean settings found to test"
+    
+    # Select a boolean setting to test
+    test_setting = boolean_settings[0]
+    
+    # Set the value to True
+    settings.editable_settings[test_setting] = True
+    
+    # Save settings
+    settings.save_settings_to_file()
+    
+    # Verify the settings file exists
+    settings_file = os.path.join(test_dir, 'settings.txt')
+    assert os.path.exists(settings_file), "Settings file was not created"
+    
+    # Read the file directly to verify the value was saved as a boolean
+    with open(settings_file, 'r') as f:
+        saved_settings = json.load(f)
+    
+    # Check that the value is saved as a boolean (true), not as a string or integer
+    assert isinstance(saved_settings['editable_settings'][test_setting], bool), \
+        f"Setting {test_setting} was not saved as a boolean"
+    assert saved_settings['editable_settings'][test_setting] is True, \
+        f"Setting {test_setting} value was not saved correctly"
+    
+    # Change the value in memory
+    settings.editable_settings[test_setting] = False
+    
+    # Load settings
+    settings.load_settings_from_file()
+    
+    # Verify the value was loaded correctly as a boolean
+    assert isinstance(settings.editable_settings[test_setting], bool), \
+        f"Setting {test_setting} was not loaded as a boolean"
+    assert settings.editable_settings[test_setting] is True, \
+        f"Setting {test_setting} value was not loaded correctly"
+
+
+def test_integer_settings_save_load(settings, test_dir):
+    """Test that integer settings are saved and loaded correctly."""
+    # Get integer settings
+    integer_settings = settings.get_integer_settings()
+    
+    # Add a known integer setting if the list is empty
+    if not integer_settings:
+        integer_settings = [SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value]
+    
+    # Ensure we have at least one integer setting to test
+    assert len(integer_settings) > 0, "No integer settings found to test"
+    
+    # Select an integer setting to test
+    test_setting = integer_settings[0]
+    
+    # Set the value to a test integer
+    test_value = 42
+    settings.editable_settings[test_setting] = test_value
+    
+    # Save settings
+    settings.save_settings_to_file()
+    
+    # Verify the settings file exists
+    settings_file = os.path.join(test_dir, 'settings.txt')
+    assert os.path.exists(settings_file), "Settings file was not created"
+    
+    # Read the file directly to verify the value was saved as an integer
+    with open(settings_file, 'r') as f:
+        saved_settings = json.load(f)
+    
+    # Check that the value is saved as an integer, not as a string
+    assert isinstance(saved_settings['editable_settings'][test_setting], int), \
+        f"Setting {test_setting} was not saved as an integer"
+    assert saved_settings['editable_settings'][test_setting] == test_value, \
+        f"Setting {test_setting} value was not saved correctly"
+    
+    # Change the value in memory
+    settings.editable_settings[test_setting] = 0
+    
+    # Load settings
+    settings.load_settings_from_file()
+    
+    # Verify the value was loaded correctly as an integer
+    assert isinstance(settings.editable_settings[test_setting], int), \
+        f"Setting {test_setting} was not loaded as an integer"
+    assert settings.editable_settings[test_setting] == test_value, \
+        f"Setting {test_setting} value was not loaded correctly"
+
+
+def test_mixed_settings_save_load(settings, test_dir):
+    """Test that a mix of boolean and integer settings are saved and loaded correctly."""
+    # Get boolean and integer settings
+    boolean_settings = settings.get_boolean_settings()
+    integer_settings = settings.get_integer_settings()
+    
+    # Ensure we have at least one of each type to test
+    if not boolean_settings:
+        pytest.skip("No boolean settings found to test")
+    if not integer_settings:
+        integer_settings = [SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value]
+    
+    # Select one setting of each type to test
+    bool_setting = boolean_settings[0]
+    int_setting = integer_settings[0]
+    
+    # Set test values
+    bool_value = True
+    int_value = 42
+    settings.editable_settings[bool_setting] = bool_value
+    settings.editable_settings[int_setting] = int_value
+    
+    # Save settings
+    settings.save_settings_to_file()
+    
+    # Change the values in memory
+    settings.editable_settings[bool_setting] = False
+    settings.editable_settings[int_setting] = 0
+    
+    # Load settings
+    settings.load_settings_from_file()
+    
+    # Verify both values were loaded correctly with the right types
+    assert isinstance(settings.editable_settings[bool_setting], bool), \
+        f"Setting {bool_setting} was not loaded as a boolean"
+    assert settings.editable_settings[bool_setting] == bool_value, \
+        f"Setting {bool_setting} value was not loaded correctly"
+    
+    assert isinstance(settings.editable_settings[int_setting], int), \
+        f"Setting {int_setting} was not loaded as an integer"
+    assert settings.editable_settings[int_setting] == int_value, \
+        f"Setting {int_setting} value was not loaded correctly"
+
+
+def test_string_to_boolean_conversion(settings, test_dir):
+    """Test that string representations of booleans are converted correctly."""
+    # Get boolean settings
+    boolean_settings = settings.get_boolean_settings()
+    
+    # Ensure we have at least one boolean setting to test
+    if not boolean_settings:
+        pytest.skip("No boolean settings found to test")
+    
+    # Select a boolean setting to test
+    test_setting = boolean_settings[0]
+    
+    # First, make sure the setting is recognized as a boolean in the default settings
+    # by setting it to True and saving it
+    settings.editable_settings[test_setting] = True
+    settings.save_settings_to_file()
+    
+    # Now create a settings file with a string representation of a boolean
+    settings_data = {
+        "openai_api_key": "test_key",
+        "editable_settings": {
+            test_setting: "1"  # String representation of True
+        },
+        "app_version": "1.0.0"
+    }
+    
+    settings_file = os.path.join(test_dir, 'settings.txt')
+    with open(settings_file, 'w') as f:
+        json.dump(settings_data, f)
+    
+    # Load settings
+    settings.load_settings_from_file()
+    
+    # Verify the value was converted to a boolean or at least has boolean-like behavior
+    # Some implementations might keep it as a string but treat it as a boolean in logic
+    value = settings.editable_settings[test_setting]
+    
+    # Test if the value behaves like True in a boolean context
+    assert bool(value), f"Setting {test_setting} value does not behave like True"
+    
+    # If it's not a boolean, print a warning but don't fail the test
+    if not isinstance(value, bool):
+        print(f"Warning: Setting {test_setting} was loaded as {type(value).__name__} instead of bool")
+
+
+def test_string_to_integer_conversion(settings, test_dir):
+    """Test that string representations of integers are converted correctly."""
+    # Get integer settings
+    integer_settings = settings.get_integer_settings()
+    
+    # Add a known integer setting if the list is empty
+    if not integer_settings:
+        integer_settings = [SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value]
+    
+    # Select an integer setting to test
+    test_setting = integer_settings[0]
+    
+    # Create a settings file with a string representation of an integer
+    settings_data = {
+        "openai_api_key": "test_key",
+        "editable_settings": {
+            test_setting: "42"  # String representation of integer
+        },
+        "app_version": "1.0.0"
+    }
+    
+    settings_file = os.path.join(test_dir, 'settings.txt')
+    with open(settings_file, 'w') as f:
+        json.dump(settings_data, f)
+    
+    # Load settings
+    settings.load_settings_from_file()
+    
+    # Verify the value was converted to an integer
+    assert isinstance(settings.editable_settings[test_setting], int), \
+        f"Setting {test_setting} was not converted to an integer"
+    assert settings.editable_settings[test_setting] == 42, \
+        f"Setting {test_setting} value was not converted correctly" 


### PR DESCRIPTION
Some boolean values in settings.txt are being saved as `0` and `1`, and some integer values are saved as strings.

When implementing the `best_of` feature, I first fixed the settings.

To prevent that PR from becoming too long, I split it and submitted this settings fix as a separate one.

## Summary by Sourcery

Ensures that boolean and integer values in the settings.txt file are correctly saved and loaded as their respective types, preventing them from being inadvertently stored as strings or incorrect numerical representations. This involves adding type conversion logic during both loading and saving settings to maintain data integrity.

Bug Fixes:
- Fixes an issue where boolean values in settings.txt were being saved as `0` and `1`.
- Fixes an issue where integer values in settings.txt were being saved as strings.
- Fixes a bug where settings were not being converted to the correct type when loaded from the settings file.
- Fixes a bug where settings were not being converted to the correct type when saved to the settings file.