### PR TITLE
fix: Remove duplicated note loading window (mac-dev)

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1458,7 +1458,6 @@ def generate_note_thread(text: str):
 
     
     loading_window.destroy()
-    loading_window = LoadingWindow(root, "Generating Note.", "Generating Note. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))
 
     loading_window = LoadingWindow(
         root,


### PR DESCRIPTION
Generating note loading window was duplicated due to a merge issue.

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the note loading window was being instantiated twice.