### PR TITLE
fix(popup): Generating Note. popup didn't disappear after note was generated (mac-dev)

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1455,19 +1455,10 @@ def generate_note_thread(text: str):
         # display the popup
         if display_screening_popup() is False:
             return
-
     
     loading_window.destroy()
     loading_window = LoadingWindow(root, "Generating Note.", "Generating Note. Please wait.", on_cancel=lambda: (cancel_note_generation(GENERATION_THREAD_ID, screen_thread)))
 
-    loading_window = LoadingWindow(
-        root,
-        "Generating Note.",
-        "Generating Note. Please wait.",
-        on_cancel=lambda: (
-            cancel_note_generation(
-                GENERATION_THREAD_ID,
-                screen_thread)))
 
     thread = threading.Thread(target=generate_note, args=(text,))
     thread.start()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix the issue where the popup did not disappear after a note was generated by ensuring the loading window is properly destroyed.