### PR TITLE
fix: properly filter out unwanted models from API response

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -495,10 +495,6 @@ class SettingsWindow():
             models = response.json().get("data", [])  # Extract the 'data' field
             if not models:
                 return ["No models available", "Custom"]
-            # Extract the 'data' field
-            models = response.json().get("data", [])  
-            if not models:
-                return ["No models available", "Custom"]
 
             unwanted_model = ["gemma2:2b-instruct-q8_0"]            
             # Filter models, checking if 'id' exists and isn't in the unwanted_model list

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -493,11 +493,17 @@ class SettingsWindow():
             response = requests.get(endpoint + "/models", headers=headers, timeout=1.0, verify=verify)
             response.raise_for_status()  # Raise an error for bad responses
             models = response.json().get("data", [])  # Extract the 'data' field
-            
+            if not models:
+                return ["No models available", "Custom"]
+            # Extract the 'data' field
+            models = response.json().get("data", [])  
             if not models:
                 return ["No models available", "Custom"]
 
-            available_models = [model["id"] for model in models]
+            unwanted_model = ["gemma2:2b-instruct-q8_0"]            
+            # Filter models, checking if 'id' exists and isn't in the unwanted_model list
+            available_models = [model["id"] for model in models if model.get("id", "") not in unwanted_model]
+            # Add "Custom" to the available models list
             available_models.append("Custom")
             return available_models
         except requests.RequestException as e:


### PR DESCRIPTION
### Changes:
- Fixed an issue where 'gemma2:2b-instruct-q8_0' was not properly excluded.
- Used `model.get("id", "")` to prevent potential key errors.

### Why:
This ensures the unwanted model is always removed from the list before being returned.

![image](https://github.com/user-attachments/assets/f3bc2d39-f68d-46fd-8f07-0c45042ef46c)

## Summary by Sourcery

Fixes an issue where the 'gemma2:2b-instruct-q8_0' model was not being properly filtered out from the API response. Uses model.get("id", "") to prevent potential key errors when filtering models.

Bug Fixes:
- Fixes an issue where the 'gemma2:2b-instruct-q8_0' model was not being properly excluded from the API response.
- Uses model.get("id", "") to prevent potential key errors when filtering models.