### PR TITLE
Fix/loading window text (mac)

### DIFF
--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -39,6 +39,10 @@ class LoadingWindow:
     >>> processing.destroy()
     """
 
+    MACOS_SIZE = (300, 125)
+    WINDOWS_SIZE = (280, 105)
+    NOTE_OFFSET = (80, 75)
+
     def __init__(self, parent=None, title="Processing", initial_text="Loading", on_cancel=None, note_text=None):
         """
         Initialize the processing popup window.
@@ -64,11 +68,20 @@ class LoadingWindow:
             
             self.popup = tk.Toplevel(parent)
             self.popup.title(title)
-            # Adjust geometry based on whether note_text is provided
-            if note_text:
-                self.popup.geometry("360x180")  # Increased height for note text
+            
+            if utils.system.is_macos():
+                size = LoadingWindow.MACOS_SIZE
+                if note_text:
+                    size = (size[0] + LoadingWindow.NOTE_OFFSET[0], size[1] + LoadingWindow.NOTE_OFFSET[1])
+                self.popup.geometry(f"{size[0]}x{size[1]}")
             else:
-                self.popup.geometry("280x105")  # Default height
+                size = LoadingWindow.WINDOWS_SIZE
+                if note_text:
+                    size = (size[0], size[1] + 20)
+                self.popup.geometry(f"{size[0]}x{size[1]}")
+
+            
+
             self.popup.iconbitmap(get_file_path('assets','logo.ico'))
 
             if parent:

--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -77,7 +77,7 @@ class LoadingWindow:
             else:
                 size = LoadingWindow.WINDOWS_SIZE
                 if note_text:
-                    size = (size[0], size[1] + 20)
+                    size = (size[0] + LoadingWindow.NOTE_OFFSET[0], size[1] + LoadingWindow.NOTE_OFFSET[1])
                 self.popup.geometry(f"{size[0]}x{size[1]}")
 
             

--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -69,18 +69,13 @@ class LoadingWindow:
             self.popup = tk.Toplevel(parent)
             self.popup.title(title)
             
-            if utils.system.is_macos():
-                size = LoadingWindow.MACOS_SIZE
-                if note_text:
-                    size = (size[0] + LoadingWindow.NOTE_OFFSET[0], size[1] + LoadingWindow.NOTE_OFFSET[1])
-                self.popup.geometry(f"{size[0]}x{size[1]}")
-            else:
-                size = LoadingWindow.WINDOWS_SIZE
-                if note_text:
-                    size = (size[0] + LoadingWindow.NOTE_OFFSET[0], size[1] + LoadingWindow.NOTE_OFFSET[1])
-                self.popup.geometry(f"{size[0]}x{size[1]}")
+            # Default windows size
+            size = LoadingWindow.MACOS_SIZE if utils.system.is_macos() else LoadingWindow.WINDOWS_SIZE
 
+            if note_text:
+                size = (size[0] + LoadingWindow.NOTE_OFFSET[0], size[1] + LoadingWindow.NOTE_OFFSET[1])
             
+            self.popup.geometry(f"{size[0]}x{size[1]}")
 
             self.popup.iconbitmap(get_file_path('assets','logo.ico'))
 

--- a/src/FreeScribe.client/utils/whisper/WhisperModel.py
+++ b/src/FreeScribe.client/utils/whisper/WhisperModel.py
@@ -59,7 +59,7 @@ def load_model_with_loading_screen(root, app_settings):
 
     model_id = get_model_from_settings(app_settings)
 
-    loading_screen = UI.LoadingWindow.LoadingWindow(root, title="Speech to Text", initial_text=f"Loading Speech to Text model ({model_id}). Please wait.",
+    loading_screen = UI.LoadingWindow.LoadingWindow(root, title="Speech to Text", initial_text=f"Loading Speech to Text model ({model_id}).\n Please wait.",
                                                     note_text="Note: If this is the first time loading the model, it will be actively downloading and may take some time.\n We appreciate your patience!")
 
     load_thread = load_stt_model(app_settings=app_settings)

--- a/src/FreeScribe.client/utils/whisper/WhisperModel.py
+++ b/src/FreeScribe.client/utils/whisper/WhisperModel.py
@@ -186,7 +186,7 @@ def _load_stt_model_windows(app_settings):
             print("Closing STT loading window.")
 
 
-def unload_stt_model():
+def unload_stt_model(event=None):
     """
     Unload the speech-to-text model from memory.
 


### PR DESCRIPTION
Fixed macos font sizings

## Summary by Sourcery

Fixes font sizing issues on macOS in the loading window, and adjusts the loading window geometry and note label font size based on the operating system.

Bug Fixes:
- Fixes font sizing issues on macOS in the loading window.
- Adjusts the loading window geometry and note label font size based on the operating system.