### PR TITLE
fix: remove help image on first start up, it's everything everywhere …

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1984,7 +1984,6 @@ root.minsize(900, 400)
 
 if (app_settings.editable_settings['Show Welcome Message']):
     window.show_welcome_message()
-    ImageWindow(root, "Help Guide", get_file_path('assets', 'help.png'))
 
 #Wait for the UI root to be intialized then load the model. If using local llm.
 if app_settings.editable_settings[SettingsKeys.LOCAL_LLM.value]:


### PR DESCRIPTION
…all at once

## Summary by Sourcery

Bug Fixes:
- Remove automatic display of help image on application startup