### PR TITLE
feat(s2t): translate to english for macos

### DIFF
--- a/src/FreeScribe.client/utils/whisper/WhisperModel.py
+++ b/src/FreeScribe.client/utils/whisper/WhisperModel.py
@@ -238,8 +238,13 @@ def _faster_whisper_transcribe_macos(audio, app_settings):
     Returns
         str: Transcribed text or error message if transcription fails.
     """
+
+    generate_kwargs = {}
+    if app_settings.editable_settings[SettingsKeys.USE_TRANSLATE_TASK.value]:
+        generate_kwargs['task'] = 'translate'
+
     # Perform transcription
-    result = stt_local_model(audio)
+    result = stt_local_model(audio, generate_kwargs=generate_kwargs)
     return result["text"]
 
 

--- a/src/FreeScribe.client/utils/whisper/WhisperModel.py
+++ b/src/FreeScribe.client/utils/whisper/WhisperModel.py
@@ -253,6 +253,7 @@ def _faster_whisper_transcribe_macos(audio, app_settings):
     # Remove silent chunks
     cleaned_audio = _remove_silent_chunks(audio)
 
+    # passing arguments to translate
     generate_kwargs = {}
     if app_settings.editable_settings[SettingsKeys.USE_TRANSLATE_TASK.value]:
         generate_kwargs['task'] = 'translate'


### PR DESCRIPTION
## Summary by Sourcery

Add support for translating audio to English on macOS using Whisper transcription

New Features:
- Enable translation task option for Whisper transcription on macOS, allowing users to translate audio to English

Enhancements:
- Modify Whisper transcription method to support optional translation task based on user settings