### PR TITLE
hot-fix(file-save-error): Fixed issue when dev settings tab was closed could not save settings. (URGENT)

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -135,6 +135,9 @@ class SettingsWindowUI:
         self.create_buttons()
 
         # "Dev" settings tab for developer mode
+        # Create the menu then disable it so the ui elements have access
+        self._enable_developer_mode(None)
+        self._disable_developer_mode(None)
         self.settings_window.bind("<Control-slash>", self._enable_developer_mode)
 
         # set the focus to this window
@@ -157,7 +160,7 @@ class SettingsWindowUI:
         """
         remove the developer tab from the notebook
         """
-        self.notebook.forget(self.developer_frame)
+        self.notebook.hide(self.developer_frame)
         self.settings_window.unbind("<Control-slash>")
         self.settings_window.bind("<Control-slash>", self._enable_developer_mode)
 


### PR DESCRIPTION
This was because we would .forget() the tab so the UI elements would not be accessible on save.

## Summary by Sourcery

Fix an issue with developer settings tab visibility and accessibility in the settings window

Bug Fixes:
- Resolved a problem where closing the developer settings tab would make UI elements inaccessible during save operations

Enhancements:
- Modified tab management to use hide() instead of forget() to preserve UI element accessibility