### PR TITLE
refactor(pre-process): Switched the pre-process prompt to dev settings and the check box to adv settings.

### DIFF
--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -27,6 +27,7 @@ class SettingsKeys(Enum):
     Enable_AI_Conversation_Validation = "Enable AI Conversation Validation"
     ENABLE_HALLUCINATION_CLEAN = "Enable Hallucination Cleaning (Experimental)"
     ENABLE_FILE_LOGGER = "Enable File Log"
+    USE_PRE_PROCESSING = "Use Pre-Processing"
 
 class Architectures(Enum):
     CPU = ("CPU", "cpu")
@@ -45,7 +46,7 @@ class FeatureToggle:
     DOCKER_SETTINGS_TAB = False
     DOCKER_STATUS_BAR = False
     POST_PROCESSING = False
-    PRE_PROCESSING = False
+    PRE_PROCESSING = True
 
 
 DEFAULT_CONTEXT_WINDOW_SIZE = 4096

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -125,7 +125,7 @@ class SettingsWindow():
             "Use Docker Status Bar": False,
             "Show Welcome Message": True,
             "Enable Scribe Template": False,
-            "Use Pre-Processing": FeatureToggle.PRE_PROCESSING,
+            SettingsKeys.USE_PRE_PROCESSING.value: FeatureToggle.PRE_PROCESSING,
             "Use Post-Processing": FeatureToggle.POST_PROCESSING,
             "AI Server Self-Signed Certificates": False,
             SettingsKeys.S2T_SELF_SIGNED_CERT.value: False,
@@ -203,7 +203,8 @@ class SettingsWindow():
             # "frmtrmblln",
             SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value,
             SettingsKeys.Enable_Word_Count_Validation.value,
-            SettingsKeys.Enable_AI_Conversation_Validation.value
+            SettingsKeys.Enable_AI_Conversation_Validation.value,
+            SettingsKeys.USE_PRE_PROCESSING.value,
         ]
 
         self.adv_whisper_settings = [

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -125,7 +125,7 @@ class SettingsWindow():
             "Use Docker Status Bar": False,
             "Show Welcome Message": True,
             "Enable Scribe Template": False,
-            SettingsKeys.USE_PRE_PROCESSING.value: FeatureToggle.PRE_PROCESSING,
+            SettingsKeys.USE_PRE_PROCESSING.value: False,
             "Use Post-Processing": FeatureToggle.POST_PROCESSING,
             "AI Server Self-Signed Certificates": False,
             SettingsKeys.S2T_SELF_SIGNED_CERT.value: False,

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -185,9 +185,17 @@ class SettingsWindowUI:
         left_frame.grid(row=row, column=0, padx=10, pady=5, sticky="nw")
         right_frame = ttk.Frame(self.developer_frame)
         right_frame.grid(row=row, column=1, padx=10, pady=5, sticky="nw")
+        
+        row += 1
 
         # load all settings from the developer settings        
         left_row, right_row = self.create_editable_settings_col(left_frame, right_frame, 0, 0, self.settings.developer_settings)
+
+        
+        if FeatureToggle.PRE_PROCESSING is True:
+            self.preprocess_text, label_row, text_row, row = self._create_text_area(
+                self.developer_frame, "Pre-Processing", self.settings.editable_settings["Pre-Processing"], row
+            )
 
         # add custom handler for log file button, additional warning for PHI
         def _on_file_logger_click(*args):
@@ -575,15 +583,6 @@ class SettingsWindowUI:
             self.create_editable_settings_col(left_frame, right_frame, 0, 0, settings)
             return row + 1
 
-        def create_processing_section(label_text, setting_key, text_content, row):
-            frame = tk.Frame(self.advanced_settings_frame, width=800)
-            frame.grid(row=row, column=0, padx=10, pady=0, sticky="nw")
-            self._create_checkbox(frame, f"Use {label_text}", setting_key, 0)
-            row += 1
-            
-            text_area, row = self._create_text_area(label_text, text_content, row)
-            return text_area, row
-
         row = self._create_section_header("⚠️ Advanced Settings (For Advanced Users Only)", 0, text_colour="red", frame=self.advanced_settings_frame)
         
         # General Settings
@@ -616,7 +615,7 @@ class SettingsWindowUI:
 
         # Pre convo instruction
         self.aiscribe_text, label_row1, text_row1, row = self._create_text_area(
-            "Pre Conversation Instruction", self.settings.AISCRIBE, row
+            self.advanced_settings_frame, "Pre Conversation Instruction", self.settings.AISCRIBE, row
         )
 
         # Explanation for Pre convo instruction
@@ -638,7 +637,7 @@ class SettingsWindowUI:
 
         # Post convo instruction
         self.aiscribe2_text, label_row2, text_row2, row = self._create_text_area(
-            "Post Conversation Instruction", self.settings.AISCRIBE2, row
+            self.advanced_settings_frame, "Post Conversation Instruction", self.settings.AISCRIBE2, row
         )
 
         # Explanation for Post convo instruction
@@ -657,24 +656,24 @@ class SettingsWindowUI:
             font=("Arial", 9),
             fg="#272927"
         ).grid(row=text_row2, column=1, padx=(10, 0), pady=5, sticky="nw")
-
-        if FeatureToggle.PRE_PROCESSING is True:
-            # Processing Sections
-            self.preprocess_text, row = create_processing_section(
-                "Pre-Processing", 
-                "Use Pre-Processing",
-                self.settings.editable_settings["Pre-Processing"],
-                row
-            )
         
         if FeatureToggle.POST_PROCESSING is True:
-            self.postprocess_text, _ = create_processing_section(
+            self.postprocess_text, _ = self.__create_processing_section(
+                self.advanced_settings_frame,
                 "Post-Processing (Experimental. Use with caution.)",
                 "Use Post-Processing", 
                 self.settings.editable_settings["Post-Processing"],
                 row
             )
 
+    def __create_processing_section(self, frame, label_text, setting_key, text_content, row):
+        button_frame = tk.Frame(frame, width=800)
+        button_frame.grid(row=row, column=0, padx=10, pady=0, sticky="nw")
+        self._create_checkbox(button_frame, f"Use {label_text}", setting_key, 0)
+        row += 1
+        
+        text_area, label_row, text_row, column_row = self._create_text_area(frame, label_text, text_content, row)
+        return text_area, row
 
     def create_docker_settings(self):
         """
@@ -948,7 +947,7 @@ class SettingsWindowUI:
             sticky="w")
         return row + 1
 
-    def _create_text_area(self, label_text, text_content, row):
+    def _create_text_area(self, frame, label_text, text_content, row):
         """
         Creates a labeled text area widget in the advanced settings frame.
         
@@ -961,11 +960,11 @@ class SettingsWindowUI:
             tuple: (Text widget object, label_row, text_row, next_row)
         """
         label_row = row
-        tk.Label(self.advanced_settings_frame, text=label_text).grid(
+        tk.Label(frame, text=label_text).grid(
             row=label_row, column=0, padx=10, pady=5, sticky="w")
         
         text_row = row + 1
-        text_area = tk.Text(self.advanced_settings_frame, height=10, width=50)
+        text_area = tk.Text(frame, height=10, width=50)
         text_area.insert(tk.END, text_content)
         text_area.grid(row=text_row, column=0, padx=10, pady=5, sticky="w")
         

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1291,7 +1291,7 @@ def generate_note(formatted_message):
             try:
                 if use_aiscribe:
                     # If pre-processing is enabled
-                    if app_settings.editable_settings["Use Pre-Processing"]:
+                    if app_settings.editable_settings[SettingsKeys.USE_PRE_PROCESSING.value]:
                         #Generate Facts List
                         list_of_facts = send_text_to_chatgpt(f"{app_settings.editable_settings['Pre-Processing']} {formatted_message}")
                         


### PR DESCRIPTION
## Summary by Sourcery

Refactor the pre-processing settings to move the pre-processing prompt to developer settings and the checkbox to advanced settings.

New Features:
- Enabled pre-processing feature toggle by default

Enhancements:
- Reorganized the placement of pre-processing settings across different settings frames

Chores:
- Updated references to pre-processing settings across multiple files
- Added a new settings key for pre-processing