### PR TITLE
feat: added a dropdown box for the whisper language codes

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -33,19 +33,8 @@ from UI.SettingsConstant import SettingsKeys, Architectures, FeatureToggle
 from UI.Widgets.PopupBox import PopupBox
 import utils.log_config
 from utils.log_config import logger
+from constants.whisper_languages import WHISPER_LANGUAGE_CODES
 
-WHISPER_LANGUAGE_CODES = [
-    "None (Auto Detect)",
-    "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
-    "sv", "it", "id", "hi", "fi", "vi", "he", "uk", "el", "ms", "cs", "ro", "da", "hu",
-    "ta", "no", "th", "ur", "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa",
-    "lv", "bn", "sr", "az", "sl", "kn", "et", "mk", "br", "eu", "is", "hy", "ne", "mn",
-    "bs", "kk", "sq", "sw", "gl", "mr", "pa", "si", "km", "sn", "yo", "so", "af", "oc",
-    "ka", "be", "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo", "ht", "ps", "tk", "nn",
-    "mt", "sa", "lb", "my", "bo", "tl", "mg", "as", "tt", "haw", "ln", "ha", "ba", "jw",
-    "su", "yue", "nan", "ceb", "hmn", "xh", "zu", "ny", "st", "gd", "sm", "chr", "co",
-    "haw", "ku", "lb", "fy", "gn", "ig", "jv", "kg", "rw", "sg", "tn", "to", "tw", "wo"
-]
 
 logger = logging.getLogger(__name__)
 

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -34,6 +34,20 @@ from UI.Widgets.PopupBox import PopupBox
 import utils.log_config
 from utils.log_config import logger
 
+WHISPER_LANGUAGE_CODES = [
+    "None (Auto Detect)",
+    "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
+    "sv", "it", "id", "hi", "fi", "vi", "he", "uk", "el", "ms", "cs", "ro", "da", "hu",
+    "ta", "no", "th", "ur", "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa",
+    "ta", "no", "th", "ur", "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa",
+    "lv", "bn", "sr", "az", "sl", "kn", "et", "mk", "br", "eu", "is", "hy", "ne", "mn",
+    "bs", "kk", "sq", "sw", "gl", "mr", "pa", "si", "km", "sn", "yo", "so", "af", "oc",
+    "ka", "be", "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo", "ht", "ps", "tk", "nn",
+    "mt", "sa", "lb", "my", "bo", "tl", "mg", "as", "tt", "haw", "ln", "ha", "ba", "jw",
+    "su", "yue", "nan", "ceb", "hmn", "xh", "zu", "ny", "st", "gd", "sm", "chr", "co",
+    "haw", "ku", "lb", "fy", "gn", "ig", "jv", "kg", "rw", "sg", "tn", "to", "tw", "wo"
+]
+
 logger = logging.getLogger(__name__)
 
 LONG_ENTRY_WIDTH = 30
@@ -623,8 +637,22 @@ class SettingsWindowUI:
         left_frame.grid(row=row, column=0, padx=10, pady=5, sticky="nw")
         right_frame = ttk.Frame(self.advanced_settings_frame)
         right_frame.grid(row=row, column=1, padx=10, pady=5, sticky="nw")
-        
-        self.create_editable_settings_col(left_frame, right_frame, 0, 0, self.settings.adv_whisper_settings)
+
+        # Create all whisper settings except language code (we'll handle that specially)
+        whisper_settings = [s for s in self.settings.adv_whisper_settings if s != SettingsKeys.WHISPER_LANGUAGE_CODE.value]
+        self.create_editable_settings_col(left_frame, right_frame, 0, 0, whisper_settings)
+
+        # Whisper Language Code Dropdown
+        tk.Label(left_frame, text=SettingsKeys.WHISPER_LANGUAGE_CODE.value).grid(row=len(whisper_settings), column=0, padx=0,
+pady=5, sticky="w")
+        self.whisper_language_dropdown = ttk.Combobox(left_frame, values=WHISPER_LANGUAGE_CODES, state="readonly")
+        current_lang = self.settings.editable_settings[SettingsKeys.WHISPER_LANGUAGE_CODE.value]
+        if current_lang in WHISPER_LANGUAGE_CODES:
+            self.whisper_language_dropdown.current(WHISPER_LANGUAGE_CODES.index(current_lang))
+        else:
+            self.whisper_language_dropdown.set(current_lang)  # Fallback to current value if not in list
+        self.whisper_language_dropdown.grid(row=len(whisper_settings), column=1, padx=0, pady=5, sticky="ew")
+        self.settings.editable_settings_entries[SettingsKeys.WHISPER_LANGUAGE_CODE.value] = self.whisper_language_dropdown
         
         # # Audio meter
         # tk.Label(left_frame, text="Whisper Audio Cutoff").grid(row=1, column=0, padx=0, pady=0, sticky="w")

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -39,7 +39,6 @@ WHISPER_LANGUAGE_CODES = [
     "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
     "sv", "it", "id", "hi", "fi", "vi", "he", "uk", "el", "ms", "cs", "ro", "da", "hu",
     "ta", "no", "th", "ur", "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa",
-    "ta", "no", "th", "ur", "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa",
     "lv", "bn", "sr", "az", "sl", "kn", "et", "mk", "br", "eu", "is", "hy", "ne", "mn",
     "bs", "kk", "sq", "sw", "gl", "mr", "pa", "si", "km", "sn", "yo", "so", "af", "oc",
     "ka", "be", "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo", "ht", "ps", "tk", "nn",

--- a/src/FreeScribe.client/constants/whisper_languages.py
+++ b/src/FreeScribe.client/constants/whisper_languages.py
@@ -1,0 +1,12 @@
+WHISPER_LANGUAGE_CODES = [
+    "None (Auto Detect)",
+    "en", "zh", "de", "es", "ru", "ko", "fr", "ja", "pt", "tr", "pl", "ca", "nl", "ar",
+    "sv", "it", "id", "hi", "fi", "vi", "he", "uk", "el", "ms", "cs", "ro", "da", "hu",
+    "ta", "no", "th", "ur", "hr", "bg", "lt", "la", "mi", "ml", "cy", "sk", "te", "fa",
+    "lv", "bn", "sr", "az", "sl", "kn", "et", "mk", "br", "eu", "is", "hy", "ne", "mn",
+    "bs", "kk", "sq", "sw", "gl", "mr", "pa", "si", "km", "sn", "yo", "so", "af", "oc",
+    "ka", "be", "tg", "sd", "gu", "am", "yi", "lo", "uz", "fo", "ht", "ps", "tk", "nn",
+    "mt", "sa", "lb", "my", "bo", "tl", "mg", "as", "tt", "haw", "ln", "ha", "ba", "jw",
+    "su", "yue", "nan", "ceb", "hmn", "xh", "zu", "ny", "st", "gd", "sm", "chr", "co",
+    "haw", "ku", "lb", "fy", "gn", "ig", "jv", "kg", "rw", "sg", "tn", "to", "tw", "wo"
+]


### PR DESCRIPTION
In the _Settings_ page, under the _Advanced Settings_ tab. A small feature was added: a dropdown box for the whisper language code selections, which was previously an input textbox. The dropdown box contains the different selections of the whisper language codes from this repo: [whisper language codes](https://github.com/SYSTRAN/faster-whisper/blob/700584b2e6c15825c73e232f323e4b910257fa1c/faster_whisper/tokenizer.py#L213-L314)

## Summary by Sourcery

Replace the text input for Whisper language code with a dropdown selection box

New Features:
- Added a dropdown box for selecting Whisper language codes with a comprehensive list of language options

Enhancements:
- Improved user interface for language code selection with a more user-friendly dropdown