### PR TITLE
Fix: Prevent error on missing recordings directory and ensure final chunk queued

### DIFF
--- a/src/FreeScribe.client/UI/RecordingsManager.py
+++ b/src/FreeScribe.client/UI/RecordingsManager.py
@@ -55,10 +55,11 @@ class RecordingsManager:
         scrollbar.config(command=self.recordings_list.yview)
 
         # Populate recordings list
-        recordings_dir = get_resource_path("recordings")
-        for f in sorted(os.listdir(recordings_dir)):
-            if f.endswith('.AE2'):
-                self.recordings_list.insert('end', f)
+        if os.path.exists(get_resource_path("recordings")):
+            recordings_dir = get_resource_path("recordings")
+            for f in sorted(os.listdir(recordings_dir)):
+                if f.endswith('.AE2'):
+                    self.recordings_list.insert('end', f)
 
         # Playback controls
         controls_frame = Frame(self.popup)

--- a/src/FreeScribe.client/UI/RecordingsManager.py
+++ b/src/FreeScribe.client/UI/RecordingsManager.py
@@ -57,9 +57,18 @@ class RecordingsManager:
         # Populate recordings list
         if os.path.exists(get_resource_path("recordings")):
             recordings_dir = get_resource_path("recordings")
+            files_found = False
             for f in sorted(os.listdir(recordings_dir)):
                 if f.endswith('.AE2'):
                     self.recordings_list.insert('end', f)
+                    files_found = True
+            
+            if not files_found:
+                self.recordings_list.insert('end', "No recordings found")
+                self.recordings_list.itemconfig(0, {'fg': 'gray'})
+        else:
+            self.recordings_list.insert('end', "No recordings found")
+            self.recordings_list.itemconfig(0, {'fg': 'gray'})
 
         # Playback controls
         controls_frame = Frame(self.popup)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -538,9 +538,9 @@ def record_audio():
 
         # Send any remaining audio chunk when recording stops
         if current_chunk:
+            audio_queue.put(b''.join(current_chunk))
             if app_settings.editable_settings[SettingsKeys.STORE_RECORDINGS_LOCALLY.value]:
                 utils.audio.encrypt_audio_chunk(b''.join(current_chunk), filepath=recording_id)
-            audio_queue.put(b''.join(current_chunk))
     except Exception as e:
         # Log the error message
         # TODO System logger

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -538,9 +538,10 @@ def record_audio():
 
         # Send any remaining audio chunk when recording stops
         if current_chunk:
-            audio_queue.put(b''.join(current_chunk))
+            last_chunk = b''.join(current_chunk)
+            audio_queue.put(last_chunk)
             if app_settings.editable_settings[SettingsKeys.STORE_RECORDINGS_LOCALLY.value]:
-                utils.audio.encrypt_audio_chunk(b''.join(current_chunk), filepath=recording_id)
+                utils.audio.encrypt_audio_chunk(last_chunk, filepath=recording_id)
     except Exception as e:
         # Log the error message
         # TODO System logger


### PR DESCRIPTION
## Summary by Sourcery

Guard against missing recordings directory when populating recordings list and ensure the final audio chunk is queued before optional encryption during recording stop.

Bug Fixes:
- Check for the recordings directory’s existence before listing files to prevent errors when it’s missing.
- Enqueue the final audio chunk before optional local encryption to guarantee it’s always queued.