### PR TITLE
refactor(experimental-settings): Put all experimental features behind a feature toggle. (dev)

### DIFF
--- a/src/FreeScribe.client/UI/MainWindowUI.py
+++ b/src/FreeScribe.client/UI/MainWindowUI.py
@@ -46,15 +46,16 @@ class MainWindowUI:
 
         self.warning_bar = None # Warning bar
         
-        # Initialize intent action system
-        maps_dir = Path(get_file_path('assets', 'maps'))
-        maps_dir.mkdir(parents=True, exist_ok=True)
-        self.intent_manager = IntentActionManager(
-            maps_dir,
-            self.app_settings.editable_settings.get("Google Maps API Key", "")
-        )
-        self.action_window = ActionResultsWindow(self.root)
-        self.action_window.hide()  # Hide initially
+        if FeatureToggle.INTENT_ACTION:
+            # Initialize intent action system
+            maps_dir = Path(get_file_path('assets', 'maps'))
+            maps_dir.mkdir(parents=True, exist_ok=True)
+            self.intent_manager = IntentActionManager(
+                maps_dir,
+                self.app_settings.editable_settings.get("Google Maps API Key", "")
+            )
+            self.action_window = ActionResultsWindow(self.root)
+            self.action_window.hide()  # Hide initially
 
         self.current_docker_status_check_id = None  # ID for the current Docker status check
         self.current_container_status_check_id = None  # ID for the current container status check

--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -50,6 +50,11 @@ class FeatureToggle:
     DOCKER_STATUS_BAR = False
     POST_PROCESSING = False
     PRE_PROCESSING = False
+    INTENT_ACTION = False
+    HALLUCINATION_CLEANING = False
+    FACTS_CHECK = False
+    BEST_OF = False
+    LLM_CONVO_PRESCREEN = False
 
 
 DEFAULT_CONTEXT_WINDOW_SIZE = 4096

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -221,7 +221,7 @@ class SettingsWindow():
         ]
         
         if FeatureToggle.LLM_CONVO_PRESCREEN:
-            self.adv_ai_settings.append(SettingsKeys.Enable_AI_Conversation_Validation)
+            self.adv_ai_settings.append(SettingsKeys.Enable_AI_Conversation_Validation.value)
 
         if FeatureToggle.BEST_OF:
             self.adv_ai_settings.append(SettingsKeys.BEST_OF.value)

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -211,7 +211,6 @@ class SettingsWindow():
             # "top_a",
             "top_k",
             "top_p",
-            SettingsKeys.BEST_OF.value,
             # "typical",
             # "sampler_order",
             # "singleline",
@@ -219,9 +218,16 @@ class SettingsWindow():
             # "frmtrmblln",
             SettingsKeys.LOCAL_LLM_CONTEXT_WINDOW.value,
             SettingsKeys.Enable_Word_Count_Validation.value,
-            SettingsKeys.Enable_AI_Conversation_Validation.value,
-            SettingsKeys.FACTUAL_CONSISTENCY_VERIFICATION.value,
         ]
+        
+        if FeatureToggle.LLM_CONVO_PRESCREEN:
+            self.adv_ai_settings.append(SettingsKeys.Enable_AI_Conversation_Validation)
+
+        if FeatureToggle.BEST_OF:
+            self.adv_ai_settings.append(SettingsKeys.BEST_OF.value)
+
+        if FeatureToggle.FACTS_CHECK:
+            self.adv_ai_settings.append(SettingsKeys.FACTUAL_CONSISTENCY_VERIFICATION.value)
 
         self.adv_whisper_settings = [
             # "Real Time Audio Length",
@@ -234,8 +240,10 @@ class SettingsWindow():
             # SettingsKeys.SILERO_SPEECH_THRESHOLD.value, 
             SettingsKeys.USE_TRANSLATE_TASK.value,
             SettingsKeys.WHISPER_LANGUAGE_CODE.value,
-            SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value,
         ]
+
+        if FeatureToggle.HALLUCINATION_CLEANING:
+            self.adv_whisper_settings.append(SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value)
 
 
         self.adv_general_settings = [

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -602,25 +602,26 @@ class SettingsWindowUI:
             row = self._create_section_header("General Settings", row, text_colour="black", frame=self.advanced_settings_frame)
             row = create_settings_columns(self.settings.adv_general_settings, row)
 
-        # Google Maps Integration
-        row = self._create_section_header("Google Maps Integration", row, frame=self.advanced_settings_frame, text_colour="black")
-        maps_frame = ttk.LabelFrame(self.advanced_settings_frame, text="API Configuration")
-        maps_frame.grid(row=row, column=0, columnspan=2, padx=10, pady=5, sticky="ew")
-        
-        ttk.Label(maps_frame, text="API Key:").grid(row=0, column=0, padx=5, pady=5)
-        maps_key_entry = ttk.Entry(maps_frame, show="*")  # Hide API key
-        maps_key_entry.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
-        maps_key_entry.insert(0, self.settings.editable_settings[SettingsKeys.GOOGLE_MAPS_API_KEY.value])
-        
-        def toggle_key_visibility():
-            current = maps_key_entry.cget("show")
-            maps_key_entry.configure(show="" if current == "*" else "*")
-        
-        ttk.Button(maps_frame, text="👁", width=3, command=toggle_key_visibility).grid(row=0, column=2, padx=5, pady=5)
-        
-        maps_frame.grid_columnconfigure(1, weight=1)  # Make the entry expand horizontally
-        self.widgets[SettingsKeys.GOOGLE_MAPS_API_KEY.value] = maps_key_entry
-        row += 1
+        if FeatureToggle.INTENT_ACTION:
+            # Google Maps Integration
+            row = self._create_section_header("Google Maps Integration", row, frame=self.advanced_settings_frame, text_colour="black")
+            maps_frame = ttk.LabelFrame(self.advanced_settings_frame, text="API Configuration")
+            maps_frame.grid(row=row, column=0, columnspan=2, padx=10, pady=5, sticky="ew")
+            
+            ttk.Label(maps_frame, text="API Key:").grid(row=0, column=0, padx=5, pady=5)
+            maps_key_entry = ttk.Entry(maps_frame, show="*")  # Hide API key
+            maps_key_entry.grid(row=0, column=1, padx=5, pady=5, sticky="ew")
+            maps_key_entry.insert(0, self.settings.editable_settings[SettingsKeys.GOOGLE_MAPS_API_KEY.value])
+            
+            def toggle_key_visibility():
+                current = maps_key_entry.cget("show")
+                maps_key_entry.configure(show="" if current == "*" else "*")
+            
+            ttk.Button(maps_frame, text="👁", width=3, command=toggle_key_visibility).grid(row=0, column=2, padx=5, pady=5)
+            
+            maps_frame.grid_columnconfigure(1, weight=1)  # Make the entry expand horizontally
+            self.widgets[SettingsKeys.GOOGLE_MAPS_API_KEY.value] = maps_key_entry
+            row += 1
 
         # Whisper Settings
         row = self._create_section_header("Whisper Settings", row, text_colour="black", frame=self.advanced_settings_frame)
@@ -814,8 +815,9 @@ class SettingsWindowUI:
         # save architecture
         self.settings.editable_settings[SettingsKeys.LLM_ARCHITECTURE.value] = self.architecture_dropdown.get()
 
-        # Save Google Maps API key
-        self.settings.editable_settings[SettingsKeys.GOOGLE_MAPS_API_KEY.value] = self.widgets[SettingsKeys.GOOGLE_MAPS_API_KEY.value].get()
+        if FeatureToggle.INTENT_ACTION:
+            # Save Google Maps API key
+            self.settings.editable_settings[SettingsKeys.GOOGLE_MAPS_API_KEY.value] = self.widgets[SettingsKeys.GOOGLE_MAPS_API_KEY.value].get()
 
         self.settings.save_settings(
             self.openai_api_key_entry.get(),

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -42,7 +42,7 @@ import librosa
 from faster_whisper import WhisperModel
 from UI.MainWindowUI import MainWindowUI
 from UI.SettingsWindow import SettingsWindow
-from UI.SettingsConstant import SettingsKeys, Architectures
+from UI.SettingsConstant import SettingsKeys, FeatureToggle
 from UI.Widgets.CustomTextBox import CustomTextBox
 from UI.LoadingWindow import LoadingWindow
 from UI.ImageWindow import ImageWindow
@@ -556,7 +556,7 @@ def realtime_text():
                         break
                     try:
                         result = faster_whisper_transcribe(audio_buffer, app_settings=app_settings)
-                        if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value]:
+                        if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value] and FeatureToggle.HALLUCINATION_CLEANING:
                             result = hallucination_cleaner.clean_text(result)
                     except Exception as e:
                         logger.exception(str(e))
@@ -602,7 +602,7 @@ def realtime_text():
 
                         if response.status_code == 200:
                             text = response.json()['text']
-                            if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value]:
+                            if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value] and FeatureToggle.HALLUCINATION_CLEANING:
                                 text = hallucination_cleaner.clean_text(text)
                             if not local_cancel_flag and not is_audio_processing_realtime_canceled.is_set():
                                 update_gui(text)
@@ -615,11 +615,12 @@ def realtime_text():
                         # close buffer. we dont need it anymore
                         buffer.close()
                 # Process intents
-                try:
-                    logger.debug(f"Processing intents for text: {intent_text}")
-                    window.get_text_intents(intent_text)
-                except Exception as e:
-                    logger.exception(f"Error processing intents: {e}")
+                if FeatureToggle.INTENT_ACTION:
+                    try:
+                        logger.debug(f"Processing intents for text: {intent_text}")
+                        window.get_text_intents(intent_text)
+                    except Exception as e:
+                        logger.exception(f"Error processing intents: {e}")
             audio_queue.task_done()
 
         # unload thestt model on low mem mode
@@ -983,7 +984,7 @@ def send_audio_to_server():
             # Transcribe the audio file using the loaded model
             try:
                 result = faster_whisper_transcribe(file_to_send, app_settings=app_settings)
-                if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value]:
+                if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value] and FeatureToggle.HALLUCINATION_CLEANING:
                     result = hallucination_cleaner.clean_text(result)
             except Exception as e:
                 logger.error(traceback.format_exc())
@@ -1075,7 +1076,7 @@ def send_audio_to_server():
                 if not is_audio_processing_whole_canceled.is_set():
                     # Update the UI with the transcribed text
                     transcribed_text = response.json()['text']
-                    if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value]:
+                    if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value] and FeatureToggle.HALLUCINATION_CLEANING:
                         transcribed_text = hallucination_cleaner.clean_text(transcribed_text)
                         try:
                             transcribed_text = hallucination_cleaner.clean_text(transcribed_text)
@@ -1506,7 +1507,7 @@ def check_and_warn_about_factual_consistency(formatted_message: str, medical_not
         Always review generated notes carefully.
     """
     # Verify factual consistency
-    if not app_settings.editable_settings[SettingsKeys.FACTUAL_CONSISTENCY_VERIFICATION.value]:
+    if not app_settings.editable_settings[SettingsKeys.FACTUAL_CONSISTENCY_VERIFICATION.value] and FeatureToggle.FACTS_CHECK:
         return
         
     inconsistent_entities = find_factual_inconsistency(formatted_message, medical_note)
@@ -2065,11 +2066,11 @@ if not app_settings.is_low_mem_mode():
         print("Using Local Whisper for transcription.")
         root.after(100, lambda: (load_model_with_loading_screen(root=root, app_settings=app_settings)))
 
-if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value]:
+if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value] and FeatureToggle.HALLUCINATION_CLEANING:
     root.after(100, lambda: (
         load_hallucination_cleaner_model(root, app_settings)))
 
-if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value]:
+if app_settings.editable_settings[SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value] and FeatureToggle.HALLUCINATION_CLEANING:
     root.after(100, lambda: (
         load_hallucination_cleaner_model(root, app_settings)))
 

--- a/src/FreeScribe.client/services/whisper_hallucination_cleaner.py
+++ b/src/FreeScribe.client/services/whisper_hallucination_cleaner.py
@@ -22,7 +22,7 @@ from spacy.tokens import Doc
 import os
 
 from UI.LoadingWindow import LoadingWindow
-from UI.SettingsConstant import SettingsKeys
+from UI.SettingsConstant import SettingsKeys, FeatureToggle
 
 # Create a punctuation string without apostrophe
 punct_without_apostrophe = string.punctuation.replace("'", "")
@@ -288,10 +288,10 @@ def load_hallucination_cleaner_model(root, settings) -> None:
     2. Settings change: new_value exists, compare with previous setting
     """
     # Get current enabled state from settings
-    current_enabled = settings.editable_settings.get(SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value)
+    current_enabled = settings.editable_settings.get(SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value) and FeatureToggle.HALLUCINATION_CLEANING
 
     # Get new value from settings panel if it exists
-    setting_entry = settings.editable_settings_entries.get(SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value)
+    setting_entry = settings.editable_settings_entries.get(SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value) and FeatureToggle.HALLUCINATION_CLEANING
     new_enabled = setting_entry.get() if setting_entry else None
 
     default_logger.info(f"Hallucination cleaner - Current: {current_enabled}, New: {new_enabled}")


### PR DESCRIPTION
## Summary by Sourcery

Refactor experimental features to be controlled by explicit feature toggles

Enhancements:
- Introduce new FeatureToggle flags for INTENT_ACTION, HALLUCINATION_CLEANING, FACTS_CHECK, BEST_OF, and LLM_CONVO_PRESCREEN
- Gate Google Maps integration UI and settings persistence behind the INTENT_ACTION toggle
- Conditionally load and apply hallucination cleaning logic and related model based on the HALLUCINATION_CLEANING toggle
- Wrap intent action system initialization and invocation behind the INTENT_ACTION toggle
- Dynamically include or exclude advanced settings options (AI conversation prescreen, best_of, factual consistency) according to their respective toggles