### PR TITLE
fix(schedule-race-condition): removed lines trying to access logwindow that wasnt built

### DIFF
--- a/src/FreeScribe.client/UI/LogWindow.py
+++ b/src/FreeScribe.client/UI/LogWindow.py
@@ -33,9 +33,6 @@ class LogWindow:
                                 title="Loading Log",
                                 initial_text="Decrypting log file…",
                                 note_text="May take a moment.")
-        loading.popup.attributes('-topmost', True)
-        loading.popup.focus_force()
-        loading.popup.grab_set()
 
         def on_done(result=None, error=None):
             loading.destroy()


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Remove calls to loading.popup.attributes('-topmost'), focus_force(), and grab_set() to avoid accessing the popup before it's built