### PR TITLE
fix(frame-issue): removed scrollable frames from llm and whisper settings.

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -125,9 +125,6 @@ class SettingsWindowUI:
 
         self.settings_window.protocol("WM_DELETE_WINDOW", self.close_window)
 
-
-        self.llm_settings_frame = self.add_scrollbar_to_frame(self.llm_settings_frame)
-        self.whisper_settings_frame = self.add_scrollbar_to_frame(self.whisper_settings_frame)
         self.advanced_settings_frame = self.add_scrollbar_to_frame(self.advanced_frame)
 
         # self.create_basic_settings()


### PR DESCRIPTION
Scrollable frames are not needed as they are not long enough and they broke the scalable entry boxes.

## Summary by Sourcery

Bug Fixes:
- Remove scrollable frames from LLM and Whisper settings to fix layout and scalable entry box issues