### PR TITLE
refactor(TimestampListbox): Use custom logger

### DIFF
--- a/src/FreeScribe.client/UI/Widgets/TimestampListbox.py
+++ b/src/FreeScribe.client/UI/Widgets/TimestampListbox.py
@@ -1,6 +1,6 @@
-import logging
 import tkinter as tk
 import tkinter.messagebox as messagebox
+from utils.log_config import logger
 
 
 class TimestampListbox(tk.Listbox):
@@ -117,15 +117,15 @@ class TimestampListbox(tk.Listbox):
                 self.edit_index = None
         except tk.TclError as e:
             # Handle Tkinter-specific errors (e.g., widget-related issues)
-            logging.exception(f"Failed to update timestamp: {str(e)}")
+            logger.exception(f"Failed to update timestamp: {str(e)}")
             messagebox.showerror("UI Error", f"Failed to update timestamp: {str(e)}")
         except ValueError as e:
             # Handle validation errors
-            logging.exception(f"Invalid timestamp format: {str(e)}")
+            logger.exception(f"Invalid timestamp format: {str(e)}")
             messagebox.showwarning("Invalid Input", f"Invalid timestamp format: {str(e)}")
         except Exception as e:
             # Log unexpected errors and re-raise them
-            logging.exception(f"Critical error while confirming timestamp edit: {str(e)}")
+            logger.exception(f"Critical error while confirming timestamp edit: {str(e)}")
             raise  # Re-raise unexpected exceptions to prevent silent failures
 
     def cancel_edit(self):
@@ -147,9 +147,9 @@ class TimestampListbox(tk.Listbox):
             messagebox.showerror("UI Error", f"Failed to update timestamp: {str(e)}")
         except ValueError as e:
             # Handle validation errors
-            logging.exception(f"Invalid timestamp format: {str(e)}")
+            logger.exception(f"Invalid timestamp format: {str(e)}")
             messagebox.showwarning("Invalid Input", f"Invalid timestamp format: {str(e)}")
         except Exception as e:
             # Log unexpected errors and re-raise them
-            logging.exception(f"Critical error while confirming timestamp edit: {str(e)}")
+            logger.exception(f"Critical error while confirming timestamp edit: {str(e)}")
             raise  # Re-raise unexpected exceptions to prevent silent failures


### PR DESCRIPTION
## Summary by Sourcery

Use the project’s configured logger in TimestampListbox for consistent exception logging instead of the root logging module.

Enhancements:
- Import the custom logger from utils.log_config and remove the built-in logging import.
- Replace all logging.exception calls with logger.exception in exception handlers.