### PR TITLE
feat(recording-time-out): auto stop recording when timeout limit is reached.

### DIFF
--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -31,6 +31,7 @@ class SettingsKeys(Enum):
     STORE_RECORDINGS_LOCALLY = "Store Recordings Locally (Encrypted)"
     USE_PRE_PROCESSING = "Use Pre-Processing"
     WHISPER_INITIAL_PROMPT = "Whisper Initial Prompt"
+    RECORDING_TIMEOUT = "Auto Stop Recording (seconds)"
 
 class Architectures(Enum):
     CPU = ("CPU", "cpu")

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -143,6 +143,7 @@ class SettingsWindow():
             SettingsKeys.STORE_NOTES_LOCALLY.value: False,
             SettingsKeys.STORE_RECORDINGS_LOCALLY.value: False,
             SettingsKeys.WHISPER_INITIAL_PROMPT.value: "None",
+            SettingsKeys.RECORDING_TIMEOUT.value: 300,
         }
 
     def __init__(self):
@@ -224,6 +225,7 @@ class SettingsWindow():
             SettingsKeys.USE_TRANSLATE_TASK.value,
             SettingsKeys.WHISPER_LANGUAGE_CODE.value,
             SettingsKeys.ENABLE_HALLUCINATION_CLEAN.value,
+            SettingsKeys.RECORDING_TIMEOUT.value,
         ]
 
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -633,7 +633,7 @@ def check_silence_warning(silence_duration):
     except ValueError:
         # If the value is invalid, default to 300 seconds
         recording_timeout = 300
-        logger.info(f"Invalid value for RECORDING_TIMEOUT: {app_settings.editable_settings[SettingsKeys.RECORDING_TIMEOUT.value]}. Defaulting to {recording_timeout}")
+        logger.warning(f"Invalid value for RECORDING_TIMEOUT: {app_settings.editable_settings[SettingsKeys.RECORDING_TIMEOUT.value]}. Defaulting to {recording_timeout}")
     
     if silence_duration >= recording_timeout:
         # If the silence duration exceeds the recording timeout, stop the recording


### PR DESCRIPTION
Prevents recording being left running.

## Summary by Sourcery

Add auto-stop recording feature based on a user-configurable silence timeout, and notify the user when recording is stopped automatically.

New Features:
- Automatically stop recording when the silent period exceeds a configurable timeout.
- Expose a new "Auto Stop Recording (seconds)" setting in the UI with a default of 300 seconds.

Enhancements:
- Return the thread object from threaded_toggle_recording to allow completion tracking.