### PR TITLE
feat(network-requests): Changed net requests to a async client to be able to stop inferencing on llm servers

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -577,7 +577,7 @@ class SettingsWindow():
 
         try:
             verify = not self.editable_settings["AI Server Self-Signed Certificates"]
-            response = requests.get(endpoint + "/models", headers=headers, verify=verify)
+            response = requests.get(endpoint + "/models", headers=headers, verify=verify, timeout=10.0)
             response.raise_for_status()  # Raise an error for bad responses
             models = response.json().get("data", [])  # Extract the 'data' field
             

--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -572,9 +572,12 @@ class SettingsWindow():
             logger.info("Invalid LLM Endpoint")
             return ["Invalid LLM Endpoint", "Custom"]
 
+        if endpoint.endswith("/"):
+            endpoint = endpoint[:-1]
+
         try:
             verify = not self.editable_settings["AI Server Self-Signed Certificates"]
-            response = requests.get(endpoint + "/models", headers=headers, timeout=1.0, verify=verify)
+            response = requests.get(endpoint + "/models", headers=headers, verify=verify)
             response.raise_for_status()  # Raise an error for bad responses
             models = response.json().get("data", [])  # Extract the 'data' field
             

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1559,35 +1559,35 @@ def send_text_to_chatgpt(edited_text, cancel_event=None):
         return send_text_to_api(edited_text, cancel_event)
     
 def generate_note(formatted_message, cancel_event):
-            try:
-                if use_aiscribe:
-                    # If pre-processing is enabled
-                    if app_settings.editable_settings[SettingsKeys.USE_PRE_PROCESSING.value]:
-                        #Generate Facts List
-                        list_of_facts = send_text_to_chatgpt(f"{app_settings.editable_settings['Pre-Processing']} {formatted_message}", cancel_event)
-                        
-                        #Make a note from the facts
-                        medical_note = send_text_to_chatgpt(f"{app_settings.AISCRIBE} {list_of_facts} {app_settings.AISCRIBE2}", cancel_event)
+    try:
+        if use_aiscribe:
+            # If pre-processing is enabled
+            if app_settings.editable_settings[SettingsKeys.USE_PRE_PROCESSING.value]:
+                #Generate Facts List
+                list_of_facts = send_text_to_chatgpt(f"{app_settings.editable_settings['Pre-Processing']} {formatted_message}", cancel_event)
+                
+                #Make a note from the facts
+                medical_note = send_text_to_chatgpt(f"{app_settings.AISCRIBE} {list_of_facts} {app_settings.AISCRIBE2}", cancel_event)
 
-                        # If post-processing is enabled check the note over
-                        if app_settings.editable_settings["Use Post-Processing"]:
-                            post_processed_note = send_text_to_chatgpt(f"{app_settings.editable_settings['Post-Processing']}\nFacts:{list_of_facts}\nNotes:{medical_note}", cancel_event)
-                            update_gui_with_response(post_processed_note)
-                        else:
-                            update_gui_with_response(medical_note)
+                # If post-processing is enabled check the note over
+                if app_settings.editable_settings["Use Post-Processing"]:
+                    post_processed_note = send_text_to_chatgpt(f"{app_settings.editable_settings['Post-Processing']}\nFacts:{list_of_facts}\nNotes:{medical_note}", cancel_event)
+                    update_gui_with_response(post_processed_note)
+                else:
+                    update_gui_with_response(medical_note)
 
-                    else: # If pre-processing is not enabled thhen just generate the note
-                        medical_note = send_text_to_chatgpt(f"{app_settings.AISCRIBE} {formatted_message} {app_settings.AISCRIBE2}", cancel_event)
+            else: # If pre-processing is not enabled thhen just generate the note
+                medical_note = send_text_to_chatgpt(f"{app_settings.AISCRIBE} {formatted_message} {app_settings.AISCRIBE2}", cancel_event)
 
-                        if app_settings.editable_settings["Use Post-Processing"]:
-                            post_processed_note = send_text_to_chatgpt(f"{app_settings.editable_settings['Post-Processing']}\nNotes:{medical_note}", cancel_event)
-                            update_gui_with_response(post_processed_note)
-                        else:
-                            update_gui_with_response(medical_note)
-                else: # do not generate note just send text directly to AI 
-                    ai_response = send_text_to_chatgpt(formatted_message, cancel_event)
-                    update_gui_with_response(ai_response)
-
+                if app_settings.editable_settings["Use Post-Processing"]:
+                    post_processed_note = send_text_to_chatgpt(f"{app_settings.editable_settings['Post-Processing']}\nNotes:{medical_note}", cancel_event)
+                    update_gui_with_response(post_processed_note)
+                else:
+                    update_gui_with_response(medical_note)
+        else: # do not generate note just send text directly to AI 
+            ai_response = send_text_to_chatgpt(formatted_message, cancel_event)
+            update_gui_with_response(ai_response)
+            
         return True
     except Exception as e:
         logger.exception(f"An error occurred: {e}")

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -133,7 +133,7 @@ def on_closing():
             pending = asyncio.all_tasks(loop)
             for task in pending:
                 task.cancel()
-    except RuntimeError:
+    except RuntimeError as e:
         logger.exception(f"Error during async cleanup: {e}")
         pass  # No running loop
 
@@ -1698,9 +1698,6 @@ def generate_note_thread(text: str):
         try:
             # Set the cancellation event first
             cancel_event.set()
-            
-            # Small delay to allow the async operations to detect cancellation
-            time.sleep(0.1)
             
             if thread_id:
                 kill_thread(thread_id)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -126,20 +126,16 @@ def on_closing():
     save_notes_history()
      
     # Cancel any pending async operations
-    try:      
-        # If there are any running async tasks, cancel them
-        if hasattr(asyncio, '_get_running_loop'):
-            try:
-                loop = asyncio.get_running_loop()
-                if loop and not loop.is_closed():
-                    # Cancel all pending tasks
-                    pending = asyncio.all_tasks(loop)
-                    for task in pending:
-                        task.cancel()
-            except RuntimeError:
-                pass  # No running loop
-    except Exception as e:
+    try:
+        loop = asyncio.get_running_loop()
+        if loop and not loop.is_closed():
+            # Cancel all pending tasks
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+    except RuntimeError:
         logger.exception(f"Error during async cleanup: {e}")
+        pass  # No running loop
 
     app_manager.cleanup()
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1408,8 +1408,8 @@ def send_text_to_api(edited_text, cancel_event):
         host=app_settings.editable_settings[SettingsKeys.LLM_ENDPOINT.value],
         api_key=app_settings.OPENAI_API_KEY,
         verify_ssl=not app_settings.editable_settings["AI Server Self-Signed Certificates"],
-        timeout=180,  # Set a reasonable timeout for the request
-        connect_timeout=10,
+        timeout=180.0,  # Set a reasonable timeout for the request
+        connect_timeout=10.0,
     )
 
     llm_client = OpenAIClient(config=network_config, root=root)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1408,6 +1408,7 @@ def send_text_to_api(edited_text, cancel_event):
         host=app_settings.editable_settings[SettingsKeys.LLM_ENDPOINT.value],
         api_key=app_settings.OPENAI_API_KEY,
         verify_ssl=not app_settings.editable_settings["AI Server Self-Signed Certificates"],
+        timeout=180,  # Set a reasonable timeout for the request
         connect_timeout=10,
     )
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1408,8 +1408,7 @@ def send_text_to_api(edited_text, cancel_event):
         host=app_settings.editable_settings[SettingsKeys.LLM_ENDPOINT.value],
         api_key=app_settings.OPENAI_API_KEY,
         verify_ssl=not app_settings.editable_settings["AI Server Self-Signed Certificates"],
-        timeout=50,
-        connect_timeout=30
+        connect_timeout=10,
     )
 
     llm_client = OpenAIClient(config=network_config, root=root)

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1404,7 +1404,7 @@ def send_text_to_api(edited_text, cancel_event):
         connect_timeout=10.0,
     )
 
-    llm_client = OpenAIClient(config=network_config, root=root)
+    llm_client = OpenAIClient(config=network_config)
 
     generated_response = llm_client.send_chat_completion_sync(
         text=edited_text,

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -126,11 +126,7 @@ def on_closing():
     save_notes_history()
      
     # Cancel any pending async operations
-    try:
-        # Set any global cancellation flags
-        global checking_active
-        checking_active = False
-        
+    try:      
         # If there are any running async tasks, cancel them
         if hasattr(asyncio, '_get_running_loop'):
             try:

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1717,6 +1717,8 @@ def generate_note_thread(text: str):
             if screen_thread and screen_thread.is_alive():
                 kill_thread(screen_thread.ident)
                 
+            # Set the note box to client canceled
+            safe_set_note_box("Note generation canceled.")
         except Exception as e:
             logger.exception(f"An error occurred: {e}")
         finally:

--- a/src/FreeScribe.client/utils/network/base.py
+++ b/src/FreeScribe.client/utils/network/base.py
@@ -1,0 +1,53 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Optional
+import httpx
+from dataclasses import dataclass
+
+class NetworkRequestError(Exception):
+    """Custom exception for network request errors."""
+    pass
+
+
+@dataclass
+class NetworkConfig:
+    """Configuration for network requests."""
+    host: str
+    api_key: str
+    verify_ssl: bool = True
+    timeout: float = 60.0
+    connect_timeout: float = 10.0
+    
+    def __post_init__(self):
+        if self.host.endswith('/'):
+            self.host = self.host[:-1]
+
+
+class BaseNetworkClient:
+    """Base class for network clients."""
+    
+    def __init__(self, config: NetworkConfig):
+        self.config = config
+        self._client: Optional[httpx.AsyncClient] = None
+    
+    async def _create_client(self) -> httpx.AsyncClient:
+        """Create and return an async HTTP client."""
+        if self._client is None:
+            timeout = httpx.Timeout(self.config.timeout, connect=self.config.connect_timeout)
+            self._client = httpx.AsyncClient(timeout=timeout, verify=self.config.verify_ssl)
+        return self._client
+    
+    async def _close_client(self):
+        """Close the HTTP client if it exists."""
+        if self._client:
+            try:
+                await self._client.aclose()
+            except Exception as e:
+                print(f"Error closing client: {e}")
+            finally:
+                self._client = None
+    
+    async def _get_client(self) -> httpx.AsyncClient:
+        """Get or create the HTTP client."""
+        if self._client is None:
+            await self._create_client()
+        return self._client

--- a/src/FreeScribe.client/utils/network/base.py
+++ b/src/FreeScribe.client/utils/network/base.py
@@ -32,7 +32,7 @@ class BaseNetworkClient:
     async def _create_client(self) -> httpx.AsyncClient:
         """Create and return an async HTTP client."""
         if self._client is None:
-            timeout = httpx.Timeout(self.config.timeout, connect=self.config.connect_timeout)
+            timeout = httpx.Timeout(self.config.timeout, connect=self.config.connect_timeout, read=self.config.timeout, write=self.config.timeout, pool=self.config.timeout)
             self._client = httpx.AsyncClient(timeout=timeout, verify=self.config.verify_ssl)
         return self._client
     

--- a/src/FreeScribe.client/utils/network/base.py
+++ b/src/FreeScribe.client/utils/network/base.py
@@ -14,6 +14,7 @@ class NetworkConfig:
     host: str
     api_key: str
     verify_ssl: bool = True
+    timeout: float = 60.0
     connect_timeout: float = 10.0
     
     def __post_init__(self):
@@ -31,7 +32,7 @@ class BaseNetworkClient:
     async def _create_client(self) -> httpx.AsyncClient:
         """Create and return an async HTTP client."""
         if self._client is None:
-            timeout = httpx.Timeout(connect=self.config.connect_timeout)
+            timeout = httpx.Timeout(self.config.timeout, connect=self.config.connect_timeout)
             self._client = httpx.AsyncClient(timeout=timeout, verify=self.config.verify_ssl)
         return self._client
     

--- a/src/FreeScribe.client/utils/network/base.py
+++ b/src/FreeScribe.client/utils/network/base.py
@@ -14,7 +14,6 @@ class NetworkConfig:
     host: str
     api_key: str
     verify_ssl: bool = True
-    timeout: float = 60.0
     connect_timeout: float = 10.0
     
     def __post_init__(self):
@@ -32,7 +31,7 @@ class BaseNetworkClient:
     async def _create_client(self) -> httpx.AsyncClient:
         """Create and return an async HTTP client."""
         if self._client is None:
-            timeout = httpx.Timeout(self.config.timeout, connect=self.config.connect_timeout)
+            timeout = httpx.Timeout(connect=self.config.connect_timeout)
             self._client = httpx.AsyncClient(timeout=timeout, verify=self.config.verify_ssl)
         return self._client
     

--- a/src/FreeScribe.client/utils/network/base.py
+++ b/src/FreeScribe.client/utils/network/base.py
@@ -1,3 +1,17 @@
+"""
+/utils/network/base.py
+
+This software is released under the AGPL-3.0 license
+Copyright (c) 2023-2024 Braedon Hendy
+
+Further updates and packaging added in 2024 through the ClinicianFOCUS initiative, 
+a collaboration with Dr. Braedon Hendy and Conestoga College Institute of Applied 
+Learning and Technology as part of the CNERG+ applied research project, 
+Unburdening Primary Healthcare: An Open-Source AI Clinician Partner Platform". 
+Prof. Michael Yingbull (PI), Dr. Braedon Hendy (Partner), 
+and Research Students - Software Developer Alex Simko, Pemba Sherpa (F24), and Naitik Patel.
+"""
+
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 import httpx
@@ -11,7 +25,23 @@ class NetworkRequestError(Exception):
 
 @dataclass
 class NetworkConfig:
-    """Configuration for network requests."""
+    """Configuration for network requests.
+    
+    This dataclass holds the configuration parameters needed for making
+    network requests, including host information, authentication, and
+    connection settings.
+    
+    :param host: The base URL or hostname for the API endpoint
+    :type host: str
+    :param api_key: Authentication key for API access
+    :type api_key: str
+    :param verify_ssl: Whether to verify SSL certificates during requests
+    :type verify_ssl: bool
+    :param timeout: General timeout for network operations in seconds
+    :type timeout: float
+    :param connect_timeout: Connection timeout in seconds
+    :type connect_timeout: float
+    """
     host: str
     api_key: str
     verify_ssl: bool = True
@@ -19,26 +49,56 @@ class NetworkConfig:
     connect_timeout: float = 10.0
     
     def __post_init__(self):
+        """Normalize the host URL by removing trailing slashes.
+        
+        This method is automatically called after initialization to ensure
+        the host URL is properly formatted without trailing slashes.
+        """
         if self.host.endswith('/'):
             self.host = self.host[:-1]
 
 
 class BaseNetworkClient:
-    """Base class for network clients."""
+    """Base class for network clients.
+    
+    This class provides a foundation for creating network clients with
+    proper connection management and resource cleanup. It handles the
+    creation and lifecycle of HTTP clients using httpx.
+    """
     
     def __init__(self, config: NetworkConfig):
+        """Initialize the network client with configuration.
+        
+        :param config: Network configuration containing connection parameters
+        :type config: NetworkConfig
+        """
         self.config = config
         self._client: Optional[httpx.AsyncClient] = None
     
     async def _create_client(self) -> httpx.AsyncClient:
-        """Create and return an async HTTP client."""
+        """Create and return an async HTTP client.
+        
+        Creates a new httpx.AsyncClient instance with timeout and SSL
+        verification settings based on the provided configuration. The
+        client is cached for reuse.
+        
+        :return: Configured async HTTP client
+        :rtype: httpx.AsyncClient
+        """
         if self._client is None:
             timeout = httpx.Timeout(self.config.timeout, connect=self.config.connect_timeout, read=self.config.timeout, write=self.config.timeout, pool=self.config.timeout)
             self._client = httpx.AsyncClient(timeout=timeout, verify=self.config.verify_ssl)
         return self._client
     
     async def _close_client(self):
-        """Close the HTTP client if it exists."""
+        """Close the HTTP client if it exists.
+        
+        Properly closes the httpx.AsyncClient to free up resources and
+        connections. Any exceptions during closure are logged but not
+        re-raised to ensure cleanup completes.
+        
+        :raises Exception: Logs but does not re-raise exceptions during client closure
+        """
         if self._client:
             try:
                 await self._client.aclose()
@@ -48,7 +108,14 @@ class BaseNetworkClient:
                 self._client = None
     
     async def _get_client(self) -> httpx.AsyncClient:
-        """Get or create the HTTP client."""
+        """Get or create the HTTP client.
+        
+        Returns the existing HTTP client if available, otherwise creates
+        a new one. This method ensures lazy initialization of the client.
+        
+        :return: Active HTTP client instance
+        :rtype: httpx.AsyncClient
+        """
         if self._client is None:
             await self._create_client()
         return self._client

--- a/src/FreeScribe.client/utils/network/base.py
+++ b/src/FreeScribe.client/utils/network/base.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 import httpx
 from dataclasses import dataclass
+from utils.log_config import logger
 
 class NetworkRequestError(Exception):
     """Custom exception for network request errors."""
@@ -42,7 +43,7 @@ class BaseNetworkClient:
             try:
                 await self._client.aclose()
             except Exception as e:
-                print(f"Error closing client: {e}")
+                logger.exception(f"Error closing client: {e}")
             finally:
                 self._client = None
     

--- a/src/FreeScribe.client/utils/network/init.py
+++ b/src/FreeScribe.client/utils/network/init.py
@@ -1,0 +1,10 @@
+"""
+Network Requests for llm and other services.
+
+This module initializes the network requests for the FreeScribe client.
+"""
+
+from .openai_client import OpenAIClient
+from .base import NetworkRequestError, NetworkConfig
+
+__all__ = ['OpenAIClient', 'NetworkConfig', 'NetworkRequestError']

--- a/src/FreeScribe.client/utils/network/openai_client.py
+++ b/src/FreeScribe.client/utils/network/openai_client.py
@@ -1,0 +1,278 @@
+import asyncio
+import json
+import httpx
+from typing import Dict, Any, Optional, List
+from .base import BaseNetworkClient, NetworkConfig, NetworkRequestError
+from utils.log_config import logger
+
+
+class OpenAIClient(BaseNetworkClient):
+    """Client for communicating with OpenAI API."""
+    
+    def __init__(self, config: NetworkConfig):
+        super().__init__(config)
+    
+    async def send_chat_completion(
+        self, 
+        text: str, 
+        model: str, 
+        stop_event: asyncio.Event,
+        system_message: Optional[str] = None,
+        **options
+    ) -> str:
+        """
+        Sends text to OpenAI API using httpx AsyncClient in a cancellable async format.
+        
+        Args:
+            text (str): The text to send to the API
+            model (str): The model name to use (e.g., 'gpt-4', 'gpt-3.5-turbo')
+            stop_event (asyncio.Event): Event to signal cancellation
+            system_message (str, optional): System message to set context
+            **options: Additional model options (temperature, max_tokens, etc.)
+            
+        Returns:
+            str: The response text or 'Error' if cancelled/failed
+        """
+        try:
+            # Check for cancellation before starting
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+            
+            # Create httpx client
+            self._client = await self._create_client()
+            
+            # Check for cancellation after client creation
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+
+            # Prepare payload for OpenAI API
+            payload = self._build_payload(text, model, system_message, **options)
+
+            # Check for cancellation before sending request
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+
+            # Send POST request to OpenAI chat endpoint
+            response = await self._send_request(payload)
+            
+            # Check for cancellation after response
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+            
+            # Extract and return response text
+            return self._parse_response(response)
+
+        except Exception as e:
+            error_message = self._handle_error(e)
+            logger.exception(f"Error in OpenAI API call: {e}")
+            return f'Error: {error_message}'
+        
+        finally:
+            await self._close_client()
+    
+    async def send_completion(
+        self, 
+        prompt: str, 
+        model: str, 
+        stop_event: asyncio.Event,
+        **options
+    ) -> str:
+        """
+        Sends text to OpenAI Completion API (for older models like text-davinci-003).
+        
+        Args:
+            prompt (str): The prompt to send to the API
+            model (str): The model name to use
+            stop_event (asyncio.Event): Event to signal cancellation
+            **options: Additional model options
+            
+        Returns:
+            str: The response text or 'Error' if cancelled/failed
+        """
+        try:
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+            
+            self._client = await self._create_client()
+            
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+
+            payload = self._build_completion_payload(prompt, model, **options)
+
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+
+            response = await self._send_completion_request(payload)
+            
+            if stop_event.is_set():
+                return 'Error: Operation cancelled'
+            
+            return self._parse_completion_response(response)
+
+        except Exception as e:
+            error_message = self._handle_error(e)
+            logger.exception(f"Error in OpenAI Completion API call: {e}")
+            return f'Error: {error_message}'
+        
+        finally:
+            await self._close_client()
+    
+    def _build_payload(
+        self, 
+        text: str, 
+        model: str, 
+        system_message: Optional[str] = None,
+        **options
+    ) -> Dict[str, Any]:
+        """Build the request payload for OpenAI Chat API."""
+        messages = []
+        
+        # Add system message if provided
+        if system_message:
+            messages.append({"role": "system", "content": system_message})
+        
+        # Add user message
+        messages.append({"role": "user", "content": text})
+        
+        payload = {
+            "model": model.strip(),
+            "messages": messages
+        }
+        
+        # Add options with validation
+        try:
+            if 'temperature' in options and options['temperature'] is not None:
+                payload["temperature"] = float(options['temperature'])
+            if 'max_tokens' in options and options['max_tokens'] is not None:
+                payload["max_tokens"] = int(options['max_tokens'])
+            if 'top_p' in options and options['top_p'] is not None:
+                payload["top_p"] = float(options['top_p'])
+            if 'frequency_penalty' in options and options['frequency_penalty'] is not None:
+                payload["frequency_penalty"] = float(options['frequency_penalty'])
+            if 'presence_penalty' in options and options['presence_penalty'] is not None:
+                payload["presence_penalty"] = float(options['presence_penalty'])
+            if 'stop' in options and options['stop'] is not None:
+                payload["stop"] = options['stop']  # Can be string or list
+            if 'stream' in options and options['stream'] is not None:
+                payload["stream"] = bool(options['stream'])
+                
+        except ValueError as e:
+            logger.exception(f"Error parsing options: {e}. Using defaults.")
+            # Set reasonable defaults for OpenAI
+            payload.update({
+                "temperature": 0.7,
+                "max_tokens": 1000,
+                "top_p": 1.0
+            })
+        
+        return payload
+    
+    def _build_completion_payload(self, prompt: str, model: str, **options) -> Dict[str, Any]:
+        """Build the request payload for OpenAI Completion API."""
+        payload = {
+            "model": model.strip(),
+            "prompt": prompt
+        }
+        
+        try:
+            if 'temperature' in options and options['temperature'] is not None:
+                payload["temperature"] = float(options['temperature'])
+            if 'max_tokens' in options and options['max_tokens'] is not None:
+                payload["max_tokens"] = int(options['max_tokens'])
+            if 'top_p' in options and options['top_p'] is not None:
+                payload["top_p"] = float(options['top_p'])
+            if 'frequency_penalty' in options and options['frequency_penalty'] is not None:
+                payload["frequency_penalty"] = float(options['frequency_penalty'])
+            if 'presence_penalty' in options and options['presence_penalty'] is not None:
+                payload["presence_penalty"] = float(options['presence_penalty'])
+            if 'stop' in options and options['stop'] is not None:
+                payload["stop"] = options['stop']
+                
+        except ValueError as e:
+            logger.exception(f"Error parsing completion options: {e}")
+            payload.update({
+                "temperature": 0.7,
+                "max_tokens": 1000
+            })
+        
+        return payload
+    
+    async def _send_request(self, payload: Dict[str, Any]) -> httpx.Response:
+        """Send the HTTP request to the OpenAI Chat API."""
+        url = f"{self.config.host}/chat/completions"
+        headers = {
+            "Authorization": f"Bearer {self.config.api_key}",
+            "Content-Type": "application/json",
+        }
+        
+        response = await self._client.post(url, json=payload, headers=headers)
+        return response
+    
+    async def _send_completion_request(self, payload: Dict[str, Any]) -> httpx.Response:
+        """Send the HTTP request to the OpenAI Completion API."""
+        url = f"{self.config.host}/completions"
+        headers = {
+            "Authorization": f"Bearer {self.config.api_key}",
+            "Content-Type": "application/json",
+        }
+        
+        response = await self._client.post(url, json=payload, headers=headers)
+        response.raise_for_status()
+        return response
+    
+    def _parse_response(self, response: httpx.Response) -> str:
+        """Parse the response from OpenAI Chat API."""
+        response_data = response.json()
+        logger.debug(f"OpenAI Chat Response: {json.dumps(response_data, indent=2)}")
+        
+        try:
+            return response_data['choices'][0]['message']['content']
+        except (KeyError, IndexError) as e:
+            logger.error(f"Error parsing OpenAI response structure: {e}")
+            logger.error(f"Response data: {response_data}")
+            return 'Error: Invalid response format from OpenAI API'
+    
+    def _parse_completion_response(self, response: httpx.Response) -> str:
+        """Parse the response from OpenAI Completion API."""
+        response_data = response.json()
+        logger.debug(f"OpenAI Completion Response: {json.dumps(response_data, indent=2)}")
+        
+        try:
+            return response_data['choices'][0]['text'].strip()
+        except (KeyError, IndexError) as e:
+            logger.error(f"Error parsing OpenAI completion response structure: {e}")
+            logger.error(f"Response data: {response_data}")
+            return 'Error: Invalid response format from OpenAI Completion API'
+    
+    def _handle_error(self, error: Exception) -> str:
+        """Handle and categorize different types of errors specific to OpenAI."""
+        if isinstance(error, httpx.ReadError):
+            return f"Network connection lost to OpenAI API. Please check your internet connection."
+        elif isinstance(error, httpx.ConnectError):
+            return f"Cannot connect to OpenAI API. Please check your internet connection."
+        elif isinstance(error, httpx.TimeoutException):
+            return f"Request timed out to OpenAI API. Please try again."
+        elif isinstance(error, httpx.HTTPStatusError):
+            status_code = error.response.status_code
+            if status_code == 401:
+                return "Invalid OpenAI API key. Please check your API key."
+            elif status_code == 429:
+                return "OpenAI API rate limit exceeded. Please wait and try again."
+            elif status_code == 400:
+                return f"Bad request to OpenAI API: {error.response.text}"
+            elif status_code == 404:
+                return "OpenAI API endpoint not found. Please check the model name."
+            else:
+                return f"OpenAI API error {status_code}: {error.response.text}"
+        else:
+            return f"OpenAI API request failed: {str(error)}"
+    
+    async def cancel_request(self):
+        """Cancel an ongoing API request by setting the stop event and closing the client."""
+        try:
+            logger.info("Cancelling OpenAI API request...")
+            await self._close_client()
+            logger.info("OpenAI API request cancelled successfully.")
+        except Exception as e:
+            logger.exception(f"Error during OpenAI API cancellation: {e}")

--- a/src/FreeScribe.client/utils/network/openai_client.py
+++ b/src/FreeScribe.client/utils/network/openai_client.py
@@ -12,9 +12,8 @@ import time
 class OpenAIClient(BaseNetworkClient):
     """Client for communicating with OpenAI API."""
     
-    def __init__(self, config: NetworkConfig, root: tk.Tk):
+    def __init__(self, config: NetworkConfig):
         super().__init__(config)
-        self.root = root
         self.cancel_monitor_thread = None
         self.monitoring_stop_event = threading.Event()
     

--- a/src/FreeScribe.client/utils/network/openai_client.py
+++ b/src/FreeScribe.client/utils/network/openai_client.py
@@ -39,33 +39,20 @@ class OpenAIClient(BaseNetworkClient):
         Returns:
             str: The response text or error message
         """
-        async def run_async():
-            return await self.send_chat_completion(
-                text=text,
-                model=model,
-                stop_event=self.stop_event,
-                threading_cancel_event=threading_cancel_event,
-                system_message=system_message,
-                **options
-            )
-
-        # Run the async function with proper event loop management
         try:
-            # Create a new event loop for this thread
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            generated_response = loop.run_until_complete(run_async())
-            return generated_response
+            return asyncio.run(
+                self.send_chat_completion(
+                    text=text,
+                    model=model,
+                    stop_event=self.stop_event,
+                    threading_cancel_event=threading_cancel_event,
+                    system_message=system_message,
+                    **options
+                )
+            )
         except Exception as e:
             logger.exception(f"Error running async function: {e}")
             return f'Error: {str(e)}'
-        finally:
-            # Clean up the event loop
-            try:
-                loop.close()
-            except Exception as e:
-                logger.exception(f"Error closing event loop: {e}")
-            asyncio.set_event_loop(None)
     
     async def send_chat_completion(
         self, 

--- a/src/FreeScribe.client/utils/network/openai_client.py
+++ b/src/FreeScribe.client/utils/network/openai_client.py
@@ -305,11 +305,11 @@ class OpenAIClient(BaseNetworkClient):
     def _handle_error(self, error: Exception) -> str:
         """Handle and categorize different types of errors specific to OpenAI."""
         if isinstance(error, httpx.ReadError):
-            return f"Network connection lost to OpenAI API. Please check your internet connection."
+            return "Network connection lost to OpenAI API. Please check your internet connection."
         elif isinstance(error, httpx.ConnectError):
-            return f"Cannot connect to OpenAI API. Please check your internet connection."
+            return "Cannot connect to OpenAI API. Please check your internet connection."
         elif isinstance(error, httpx.TimeoutException):
-            return f"Request timed out to OpenAI API. Please try again."
+            return "Request timed out to OpenAI API. Please try again."
         elif isinstance(error, httpx.HTTPStatusError):
             status_code = error.response.status_code
             if status_code == 401:

--- a/src/FreeScribe.client/utils/network/openai_client.py
+++ b/src/FreeScribe.client/utils/network/openai_client.py
@@ -59,6 +59,13 @@ class OpenAIClient(BaseNetworkClient):
         except Exception as e:
             logger.exception(f"Error running async function: {e}")
             return f'Error: {str(e)}'
+        finally:
+            # Clean up the event loop
+            try:
+                loop.close()
+            except Exception as e:
+                logger.exception(f"Error closing event loop: {e}")
+            asyncio.set_event_loop(None)
     
     async def send_chat_completion(
         self, 


### PR DESCRIPTION
## Summary by Sourcery

Implement cancellable LLM network operations by integrating a new async OpenAIClient, propagating cancellation events through API calls and note generation threads, and performing cleanup on exit.

New Features:
- Allow cancellation of ongoing note generation via a threading.Event and updated cancel_note_generation logic.
- Introduce a new OpenAIClient using httpx and asyncio to perform cancellable, asynchronous LLM API requests.
- Register on_closing handler to save notes and cancel any pending asyncio tasks when the application exits.

Enhancements:
- Refactor send_text_to_api, send_text_to_chatgpt, and generate_note to accept and propagate a cancel_event.
- Wrap note generation threads with a cleanup wrapper to ensure cancellation events are set upon completion or error.
- Trim trailing slashes from LLM endpoint URLs in SettingsWindow before making model requests.

Chores:
- Remove legacy requests-based API call implementation and replace it with the new network client classes.