### PR TITLE
fix(factual-consistency): Fix skip logic conditional

### DIFF
--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -56,7 +56,7 @@ class FeatureToggle:
     PRE_PROCESSING = False
     INTENT_ACTION = False
     HALLUCINATION_CLEANING = False
-    FACTS_CHECK = False
+    FACTS_CHECK = True
     BEST_OF = False
     LLM_CONVO_PRESCREEN = False
 

--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1661,7 +1661,7 @@ def check_and_warn_about_factual_consistency(formatted_message: str, medical_not
         Always review generated notes carefully.
     """
     # Verify factual consistency
-    if not app_settings.editable_settings[SettingsKeys.FACTUAL_CONSISTENCY_VERIFICATION.value] and FeatureToggle.FACTS_CHECK:
+    if not app_settings.editable_settings[SettingsKeys.FACTUAL_CONSISTENCY_VERIFICATION.value] or not FeatureToggle.FACTS_CHECK:
         return
         
     inconsistent_entities = find_factual_inconsistency(formatted_message, medical_note)


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the conditional in check_and_warn_about_factual_consistency to only skip consistency verification when both the FACTUAL_CONSISTENCY_VERIFICATION setting and the FACTS_CHECK feature toggle are disabled.