### PR TITLE
fix(LoadingWindow): Fixed race condition for destroy trying to destroy not built window.

### DIFF
--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -138,15 +138,15 @@ class LoadingWindow:
 
             # Disable closing of the popup manually
             self.popup.protocol("WM_DELETE_WINDOW", lambda: None)
+            
+            logger.debug("LoadingWindow UI built successfully")
+            self.ui_built = True
         except Exception:
             logger.exception("Error creating LoadingWindow")
             # Enable the window on exception
             if self.parent:
                 UI.Helpers.enable_parent_window(self.parent, self.popup)
             raise
-        finally:
-            logger.debug("LoadingWindow UI built successfully")
-            self.ui_built = True
 
     def _handle_cancel(self):
         """

--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -190,7 +190,7 @@ class LoadingWindow:
             while not self.ui_built:
                 elapsed_time = time.time() - start_time
                 if int(elapsed_time) % 2 == 0 or elapsed_time < 1:
-                    logger.info(f"LoadingWindow UI not built yet, waiting for it to be built... elapsed_time: {elapsed_time:.1f} to self.ui_built: {self.ui_built}")
+                    logger.info(f"Waiting for LoadingWindowUI to build (elapsed={elapsed_time}s, built={self.ui_built})")
                 time.sleep(0.1)
             
             logger.debug("LoadingWindow UI is built, proceeding to destroy it")


### PR DESCRIPTION
Added a wait until ui_built var is set to destroy.

## Summary by Sourcery

Fix race condition in LoadingWindow.destroy by waiting for the UI to be fully built before cleaning up.

Bug Fixes:
- Ensure LoadingWindow.destroy waits until UI build completes to avoid errors when destroying a non-existent window.

Enhancements:
- Introduce a ui_built flag and wait loop in destroy() to synchronize UI lifecycle.
- Add detailed logging during UI build and teardown.
- Use parent.after to defer destruction when possible for thread-safe cleanup.