### PR TITLE
fix(SettingsWindow): Caught UnicodeEncodeError and display invalid character to pop up.

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -442,9 +442,9 @@ class SettingsWindow():
         self.AISCRIBE2 = aiscribe2_text
 
         with open(get_resource_path('aiscribe.txt'), 'w') as f:
-            f.write(self.AISCRIBE)
+            return self.write_scribe_data(f, self.AISCRIBE)
         with open(get_resource_path('aiscribe2.txt'), 'w') as f:
-            f.write(self.AISCRIBE2)
+            return self.write_scribe_data(f, self.AISCRIBE2)
 
     def load_aiscribe_from_file(self):
         """
@@ -747,11 +747,11 @@ class SettingsWindow():
         if not os.path.exists(get_resource_path('aiscribe.txt')):
             logger.info("AIScribe file not found. Creating default AIScribe file.")
             with open(get_resource_path('aiscribe.txt'), 'w') as f:
-                f.write(self.AISCRIBE)
+                return self.write_scribe_data(f, self.AISCRIBE)
         if not os.path.exists(get_resource_path('aiscribe2.txt')):
             logger.info("AIScribe2 file not found. Creating default AIScribe2 file.")
             with open(get_resource_path('aiscribe2.txt'), 'w') as f:
-                f.write(self.AISCRIBE2)
+                return self.write_scribe_data(f, self.AISCRIBE2)
 
     def get_available_architectures(self):
         """
@@ -809,3 +809,32 @@ class SettingsWindow():
             bool: The value of the 'Use Low Memory Mode' setting
         """
         return self.editable_settings[SettingsKeys.USE_LOW_MEM_MODE.value]
+    
+    def write_scribe_data(self, file, text):
+        """
+        Writes the provided text to a file, handling UnicodeEncodeError gracefully.
+        This method attempts to write the given text to the specified file. If a UnicodeEncodeError occurs,
+        it will catch the exception and display an error message to the user, indicating that the text contains
+        unsupported characters. The method will return False if the write operation fails due to an unsupported character
+
+        :param file: The file object to write to.
+        :type file: file-like object
+        :param text: The text to write to the file.
+        :type text: str
+        :returns: True if the write operation is successful, False if it fails due to an
+        unsupported character.
+        :rtype: bool
+        """
+        try:
+            file.write(text)
+        except UnicodeEncodeError as e:
+            problematic_char = e.object[e.start:e.end]
+            import tkinter.messagebox as messagebox
+            messagebox.showerror(
+                "Invalid Character", 
+                f"Settings contain an unsupported character: '{problematic_char}'\n"
+                f"Please remove special symbols and save again."
+            )
+            logger.exception("Failed to write scribe data due to unsupported character")
+            return False
+        return True

--- a/src/FreeScribe.client/UI/SettingsWindowUI.py
+++ b/src/FreeScribe.client/UI/SettingsWindowUI.py
@@ -916,16 +916,18 @@ pady=5, sticky="w")
             # Save Google Maps API key
             self.settings.editable_settings[SettingsKeys.GOOGLE_MAPS_API_KEY.value] = self.widgets[SettingsKeys.GOOGLE_MAPS_API_KEY.value].get()
 
-
-        self.settings.save_settings(
-            self.openai_api_key_entry.get(),
-            self.aiscribe_text.get("1.0", "end-1c"), # end-1c removes the trailing newline
-            self.aiscribe2_text.get("1.0", "end-1c"), # end-1c removes the trailing newline
-            self.settings_window,
-            # self.api_dropdown.get(),
-            self.settings.editable_settings["Silence cut-off"], # Save the old one for whisper audio cutoff, will be removed in future, left in incase we go back to old cut off
-            # self.cutoff_slider.threshold / 32768, # old threshold 
-        )
+        
+        if not self.settings.save_settings(
+                self.openai_api_key_entry.get(),
+                self.aiscribe_text.get("1.0", "end-1c"), # end-1c removes the trailing newline
+                self.aiscribe2_text.get("1.0", "end-1c"), # end-1c removes the trailing newline
+                self.settings_window,
+                # self.api_dropdown.get(),
+                self.settings.editable_settings["Silence cut-off"], # Save the old one for whisper audio cutoff, will be removed in future, left in incase we go back to old cut off
+                # self.cutoff_slider.threshold / 32768, # old threshold 
+            ):
+            close_window = False
+            return
         # send load event after the settings are saved
         if update_whisper_model_flag:
             self.main_window.root.event_generate("<<LoadSttModel>>")


### PR DESCRIPTION
…arcter to pop up.

This would happen when trying to save invalid char type.

## Summary by Sourcery

Handle UnicodeEncodeError when saving settings by introducing centralized error-handling for scribe file writes and preventing the settings window from closing on failure.

Bug Fixes:
- Prevent crashes on UnicodeEncodeError during settings save by catching the exception and showing an error dialog.

Enhancements:
- Add write_scribe_data method to encapsulate file writing with UnicodeEncodeError handling.
- Refactor aiscribe.txt and aiscribe2.txt writes to use write_scribe_data in both saving and initial setup.
- Keep the settings window open if saving fails due to unsupported characters.