### PR TITLE
fix(SettingsWindow): Trim white spaces from API keys and Endpoints in settings on save.

### DIFF
--- a/src/FreeScribe.client/UI/SettingsWindow.py
+++ b/src/FreeScribe.client/UI/SettingsWindow.py
@@ -426,7 +426,8 @@ class SettingsWindow():
         :param str aiscribe2_text: The text for the second AI Scribe.
         :param tk.Toplevel settings_window: The settings window instance to be destroyed after saving.
         """
-        self.OPENAI_API_KEY = openai_api_key
+        # Ensure no leading/trailing spaces
+        self.OPENAI_API_KEY = openai_api_key.strip()
         # self.API_STYLE = api_style
 
         self.editable_settings["Silence cut-off"] = silence_cutoff
@@ -435,6 +436,14 @@ class SettingsWindow():
             value = entry.get()
             # Convert the value to the appropriate type based on the setting name
             self.editable_settings[setting] = self.convert_setting_value(setting, value)
+
+            # trim any blank spaces or new char lines for endpoints and API keys
+            if setting in [SettingsKeys.LLM_ENDPOINT.value, 
+                          SettingsKeys.WHISPER_ENDPOINT.value,
+                          SettingsKeys.WHISPER_SERVER_API_KEY.value]:
+                value = entry.get()
+                self.editable_settings[setting] = value.strip()
+
 
         self.save_settings_to_file()
 


### PR DESCRIPTION
This prevents invisble chars preventing communication to containers

## Summary by Sourcery

Trim whitespace from API keys and endpoint settings on save to prevent invisible characters from blocking communication

Bug Fixes:
- Strip leading/trailing whitespace from OPENAI API key on save
- Strip leading/trailing whitespace from LLM endpoint, Whisper endpoint, and Whisper server API key entries on save