### PR TITLE
refactor(FactCheck): Disabled fact check in the feature toggle.

### DIFF
--- a/src/FreeScribe.client/UI/SettingsConstant.py
+++ b/src/FreeScribe.client/UI/SettingsConstant.py
@@ -50,13 +50,14 @@ class Architectures(Enum):
 
 
 class FeatureToggle:
+    # False by default, set to True to enable
     DOCKER_SETTINGS_TAB = False
     DOCKER_STATUS_BAR = False
     POST_PROCESSING = False
     PRE_PROCESSING = False
     INTENT_ACTION = False
     HALLUCINATION_CLEANING = False
-    FACTS_CHECK = True
+    FACTS_CHECK = False
     BEST_OF = False
     LLM_CONVO_PRESCREEN = False
 


### PR DESCRIPTION
## Summary by Sourcery

Disable the FACTS_CHECK feature by default in the feature toggle configuration and add a comment to clarify toggle defaults

Enhancements:
- Set FACTS_CHECK feature toggle default to false
- Add comment clarifying default state of feature toggles