### PR TITLE
Fix: Ok button in new template pop

### DIFF
--- a/src/FreeScribe.client/UI/NoteStyleSelector.py
+++ b/src/FreeScribe.client/UI/NoteStyleSelector.py
@@ -615,7 +615,7 @@ class StyleDialog:
             self.name_entry.focus_set()
             return
         else:
-            if not is_edit and name in NoteStyleSelector.template_options:
+            if not is_edit and name in NoteStyleSelector.style_options:
                 self.show_error_warning(f"⚠️ Template '{name}' already exists - Please choose a different name")
                 return
     


### PR DESCRIPTION
Referencing invalid variable changed to the correct one.

## Summary by Sourcery

Bug Fixes:
- Use style_options instead of template_options when checking for existing note style names in ok_clicked