### PR TITLE
refactor(LoadingWindow): made the build check in destroy threaded to not block main UI.

### DIFF
--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -184,16 +184,7 @@ class LoadingWindow:
         >>> # Do some processing
         >>> popup.destroy()  # Properly clean up and close the window
         """
-        def _destroy_ui():
-            start_time = time.time()
-            logger.debug("Waiting for LoadingWindow UI to be built")
-            while not self.ui_built:
-                elapsed_time = time.time() - start_time
-                if int(elapsed_time) % 2 == 0 or elapsed_time < 1:
-                    logger.info(f"Waiting for LoadingWindowUI to build (elapsed={elapsed_time}s, built={self.ui_built})")
-                time.sleep(0.1)
-            
-            logger.debug("LoadingWindow UI is built, proceeding to destroy it")
+        def _destroy_ui_main_thread():
             if self.popup:
                 # Enable the parent window
                 if self.parent:
@@ -210,7 +201,20 @@ class LoadingWindow:
                     logger.debug("Destroying popup window")
                     self.popup.destroy()
 
+        def _wait_for_ui_and_destroy():
+            start_time = time.time()
+            logger.debug("Waiting for LoadingWindow UI to be built")
+            while not self.ui_built:
+                elapsed_time = time.time() - start_time
+                if int(elapsed_time) % 2 == 0 or elapsed_time < 1:
+                    logger.info(f"Waiting for LoadingWindowUI to build (elapsed={elapsed_time}s, built={self.ui_built})")
+                time.sleep(0.1)
+                
+            # Schedule the UI destruction on the main thread
+            logger.debug("LoadingWindow UI is built, proceeding to destroy it")
+            self.popup.after(0, _destroy_ui_main_thread)
+
         # Run the destroy logic in a separate thread to make it non-blocking
-        destroy_thread = threading.Thread(target=_destroy_ui, daemon=True)
+        destroy_thread = threading.Thread(target=_wait_for_ui_and_destroy, daemon=True)
         destroy_thread.start()
 

--- a/src/FreeScribe.client/UI/LoadingWindow.py
+++ b/src/FreeScribe.client/UI/LoadingWindow.py
@@ -5,6 +5,7 @@ from utils.log_config import logger
 import utils.system
 import UI.Helpers
 import time
+import threading
 
 class LoadingWindow:
     """
@@ -183,7 +184,6 @@ class LoadingWindow:
         >>> # Do some processing
         >>> popup.destroy()  # Properly clean up and close the window
         """
-        # wait for the UI to be built
         def _destroy_ui():
             start_time = time.time()
             logger.debug("Waiting for LoadingWindow UI to be built")
@@ -210,11 +210,7 @@ class LoadingWindow:
                     logger.debug("Destroying popup window")
                     self.popup.destroy()
 
-        if self.parent and hasattr(self.parent, 'after'):
-            logger.debug("Using parent.after to destroy LoadingWindow UI")
-            self.parent.after(0, _destroy_ui)
-        else:
-            # Call the destroy function directly if parent is not available
-            logger.debug("Parent not available, calling _destroy_ui directly")
-            _destroy_ui()
+        # Run the destroy logic in a separate thread to make it non-blocking
+        destroy_thread = threading.Thread(target=_destroy_ui, daemon=True)
+        destroy_thread.start()
 


### PR DESCRIPTION
## Summary by Sourcery

Refactor LoadingWindow.destroy to execute the build check in a background thread and schedule widget cleanup on the main thread to keep the UI responsive

Enhancements:
- Import threading and spawn a daemon thread to wait for ui_built instead of blocking the main thread
- Move popup destruction into a separate function invoked via popup.after on the main thread once the UI is built