### PR TITLE
refactor(flashing-circle): pass the function address to the root.after call to give it callable method instead of return result with ()

### DIFF
--- a/src/FreeScribe.client/client.py
+++ b/src/FreeScribe.client/client.py
@@ -1776,7 +1776,7 @@ def upload_file():
 def start_flashing():
     global is_flashing
     is_flashing = True
-    root.after(0, flash_circle())
+    root.after(0, flash_circle)
 
 
 def stop_flashing():


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Pass the flash_circle function itself to root.after rather than invoking it in start_flashing